### PR TITLE
cmd/umoci: tag: fix tag clobbering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `CHANGELOG.md` has now been added. openSUSE/umoci#76
 
+### Fixed
+- `umoci tag` would fail to clobber existing tags, which was in contrast to how
+  the rest of the tag clobbering commands operated. This has been fixed and is
+  now consistent with the other commands. openSUSE/umoci#78
+
 ## [0.0.0] - 2017-02-07
 ### Added
 - Unit tests are massively expanded, as well as the integration tests.

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -93,6 +93,40 @@ function teardown() {
 	[ "$status" -ne 0 ]
 }
 
+@test "umoci tag [clobber]" {
+	# Get blob and mediatype that a tag references.
+	umoci list --layout "${IMAGE}"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Make a copy of the tag.
+	umoci tag --image "${IMAGE}:${TAG}" "${TAG}-newtag"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Modify the configuration.
+	umoci config --author="Someone" --image "${IMAGE}:${TAG}-newtag"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Clobber the tag.
+	umoci tag --image "${IMAGE}:${TAG}" "${TAG}-newtag"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Compare the stats.
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	oldOutput="$output"
+	umoci stat --image "${IMAGE}:${TAG}-newtag" --json
+	[ "$status" -eq 0 ]
+	newOutput="$output"
+
+	[[ "$oldOutput" == "$newOutput" ]]
+
+	image-verify "${IMAGE}"
+}
+
 @test "umoci remove" {
 	# How many tags?
 	umoci list --layout "${IMAGE}"


### PR DESCRIPTION
Previously, tags would always be clobbered, but this logic was subtly
broken for "umoci tag". Fix this by matching the other PutReference
usages.

Ensure that we don't get a regression for "umoci tag" clobbering.

Fixes: 8b73b49 ("*: make logging [log.Info] much more user-friendly")
Signed-off-by: Aleksa Sarai <asarai@suse.de>