### PR TITLE
oci: cas: *ispec.Descriptor -> ispec.Descriptor

### DIFF
--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -135,7 +135,7 @@ func config(ctx *cli.Context) error {
 		return errors.Wrap(err, "get from reference")
 	}
 
-	mutator, err := mutate.New(engine, *fromDescriptor)
+	mutator, err := mutate.New(engine, fromDescriptor)
 	if err != nil {
 		return errors.Wrap(err, "create mutator for manifest")
 	}
@@ -285,7 +285,7 @@ func config(ctx *cli.Context) error {
 
 	log.Infof("new image manifest created: %s", newDescriptor.Digest)
 
-	err = engine.PutReference(context.Background(), tagName, &newDescriptor)
+	err = engine.PutReference(context.Background(), tagName, newDescriptor)
 	if err == cas.ErrClobber {
 		// We have to clobber a tag.
 		log.Warnf("clobbering existing tag: %s", tagName)
@@ -294,7 +294,7 @@ func config(ctx *cli.Context) error {
 		if err := engine.DeleteReference(context.Background(), tagName); err != nil {
 			return errors.Wrap(err, "delete old tag")
 		}
-		err = engine.PutReference(context.Background(), tagName, &newDescriptor)
+		err = engine.PutReference(context.Background(), tagName, newDescriptor)
 	}
 	if err != nil {
 		return errors.Wrap(err, "add new tag")

--- a/cmd/umoci/new.go
+++ b/cmd/umoci/new.go
@@ -82,7 +82,7 @@ func newImage(ctx *cli.Context) error {
 
 	// Update config and create a new blob for it.
 	config := g.Image()
-	configDigest, configSize, err := engine.PutBlobJSON(context.Background(), &config)
+	configDigest, configSize, err := engine.PutBlobJSON(context.Background(), config)
 	if err != nil {
 		return errors.Wrap(err, "put config blob")
 	}
@@ -128,7 +128,7 @@ func newImage(ctx *cli.Context) error {
 
 	log.Infof("new image manifest created: %s", descriptor.Digest)
 
-	err = engine.PutReference(context.Background(), tagName, &descriptor)
+	err = engine.PutReference(context.Background(), tagName, descriptor)
 	if err == cas.ErrClobber {
 		// We have to clobber a tag.
 		log.Warnf("clobbering existing tag: %s", tagName)
@@ -137,7 +137,7 @@ func newImage(ctx *cli.Context) error {
 		if err := engine.DeleteReference(context.Background(), tagName); err != nil {
 			return errors.Wrap(err, "delete old tag")
 		}
-		err = engine.PutReference(context.Background(), tagName, &descriptor)
+		err = engine.PutReference(context.Background(), tagName, descriptor)
 	}
 	if err != nil {
 		return errors.Wrap(err, "add new tag")

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -204,7 +204,7 @@ func repack(ctx *cli.Context) error {
 
 	log.Infof("new image manifest created: %s", newDescriptor.Digest)
 
-	err = engine.PutReference(context.Background(), tagName, &newDescriptor)
+	err = engine.PutReference(context.Background(), tagName, newDescriptor)
 	if err == cas.ErrClobber {
 		// We have to clobber a tag.
 		log.Warnf("clobbering existing tag: %s", tagName)
@@ -213,7 +213,7 @@ func repack(ctx *cli.Context) error {
 		if err := engine.DeleteReference(context.Background(), tagName); err != nil {
 			return errors.Wrap(err, "delete old tag")
 		}
-		err = engine.PutReference(context.Background(), tagName, &newDescriptor)
+		err = engine.PutReference(context.Background(), tagName, newDescriptor)
 	}
 	if err != nil {
 		return errors.Wrap(err, "add new tag")

--- a/cmd/umoci/stat.go
+++ b/cmd/umoci/stat.go
@@ -76,7 +76,7 @@ func stat(ctx *cli.Context) error {
 	}
 
 	// Get stat information.
-	ms, err := Stat(context.Background(), engine, *manifestDescriptor)
+	ms, err := Stat(context.Background(), engine, manifestDescriptor)
 	if err != nil {
 		return errors.Wrap(err, "stat")
 	}

--- a/cmd/umoci/utils.go
+++ b/cmd/umoci/utils.go
@@ -188,23 +188,25 @@ func Stat(ctx context.Context, engine cas.Engine, manifestDescriptor ispec.Descr
 	}
 
 	// We have to get the actual manifest.
-	manifestBlob, err := cas.FromDescriptor(ctx, engine, &manifestDescriptor)
+	manifestBlob, err := cas.FromDescriptor(ctx, engine, manifestDescriptor)
 	if err != nil {
 		return stat, err
 	}
-	manifest, ok := manifestBlob.Data.(*ispec.Manifest)
+	manifest, ok := manifestBlob.Data.(ispec.Manifest)
 	if !ok {
-		return stat, errors.Errorf("stat: cannot convert manifestBlob to manifest")
+		// Should _never_ be reached.
+		return stat, errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
 	}
 
 	// Now get the config.
-	configBlob, err := cas.FromDescriptor(ctx, engine, &manifest.Config)
+	configBlob, err := cas.FromDescriptor(ctx, engine, manifest.Config)
 	if err != nil {
 		return stat, errors.Wrap(err, "stat")
 	}
-	config, ok := configBlob.Data.(*ispec.Image)
+	config, ok := configBlob.Data.(ispec.Image)
 	if !ok {
-		return stat, errors.Errorf("stat: cannot convert configBlob to config")
+		// Should _never_ be reached.
+		return stat, errors.Errorf("[internal error] unknown config blob type: %s", configBlob.MediaType)
 	}
 
 	// TODO: This should probably be moved into separate functions.

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -75,37 +75,37 @@ type Meta struct {
 func (m *Mutator) cache(ctx context.Context) error {
 	// We need the manifest
 	if m.manifest == nil {
-		blob, err := cas.FromDescriptor(ctx, m.engine, &m.source)
+		blob, err := cas.FromDescriptor(ctx, m.engine, m.source)
 		if err != nil {
 			return errors.Wrap(err, "cache source manifest")
 		}
 		defer blob.Close()
 
-		manifest, ok := blob.Data.(*ispec.Manifest)
+		manifest, ok := blob.Data.(ispec.Manifest)
 		if !ok {
-			// Should never be reached.
-			return errors.Errorf("unknown manifest blob type: %s", blob.MediaType)
+			// Should _never_ be reached.
+			return errors.Errorf("[internal error] unknown manifest blob type: %s", blob.MediaType)
 		}
 
 		// Make a copy of the manifest.
-		m.manifest = manifestPtr(*manifest)
+		m.manifest = manifestPtr(manifest)
 	}
 
 	if m.config == nil {
-		blob, err := cas.FromDescriptor(ctx, m.engine, &m.manifest.Config)
+		blob, err := cas.FromDescriptor(ctx, m.engine, m.manifest.Config)
 		if err != nil {
 			return errors.Wrap(err, "cache source config")
 		}
 		defer blob.Close()
 
-		config, ok := blob.Data.(*ispec.Image)
+		config, ok := blob.Data.(ispec.Image)
 		if !ok {
-			// Should never be reached.
-			return errors.Errorf("unknown config blob type: %s", blob.MediaType)
+			// Should _never_ be reached.
+			return errors.Errorf("[internal error] unknown config blob type: %s", blob.MediaType)
 		}
 
 		// Make a copy of the config and configDescriptor.
-		m.config = configPtr(*config)
+		m.config = configPtr(config)
 	}
 
 	return nil

--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -84,7 +84,7 @@ type Engine interface {
 	// without implying "because of this PutReference() call". ErrClobber is
 	// returned if there is already a descriptor stored at NAME, but does not
 	// match the descriptor requested to be stored.
-	PutReference(ctx context.Context, name string, descriptor *ispec.Descriptor) (err error)
+	PutReference(ctx context.Context, name string, descriptor ispec.Descriptor) (err error)
 
 	// GetBlob returns a reader for retrieving a blob from the image, which the
 	// caller must Close(). Returns os.ErrNotExist if the digest is not found.
@@ -92,7 +92,7 @@ type Engine interface {
 
 	// GetReference returns a reference from the image. Returns os.ErrNotExist
 	// if the name was not found.
-	GetReference(ctx context.Context, name string) (descriptor *ispec.Descriptor, err error)
+	GetReference(ctx context.Context, name string) (descriptor ispec.Descriptor, err error)
 
 	// DeleteBlob removes a blob from the image. This is idempotent; a nil
 	// error means "the content is not in the store" without implying "because

--- a/oci/cas/cas_test.go
+++ b/oci/cas/cas_test.go
@@ -270,7 +270,7 @@ func TestEngineReference(t *testing.T) {
 		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
 		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
 	} {
-		if err := engine.PutReference(ctx, test.name, &test.descriptor); err != nil {
+		if err := engine.PutReference(ctx, test.name, test.descriptor); err != nil {
 			t.Errorf("PutReference: unexpected error: %+v", err)
 		}
 
@@ -279,7 +279,7 @@ func TestEngineReference(t *testing.T) {
 			t.Errorf("GetReference: unexpected error: %+v", err)
 		}
 
-		if !reflect.DeepEqual(test.descriptor, *gotDescriptor) {
+		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
 			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
 		}
 

--- a/oci/cas/dir.go
+++ b/oci/cas/dir.go
@@ -219,7 +219,7 @@ func (e *dirEngine) PutBlobJSON(ctx context.Context, data interface{}) (digest.D
 // without implying "because of this PutReference() call". ErrClobber is
 // returned if there is already a descriptor stored at NAME, but does not
 // match the descriptor requested to be stored.
-func (e *dirEngine) PutReference(ctx context.Context, name string, descriptor *ispec.Descriptor) error {
+func (e *dirEngine) PutReference(ctx context.Context, name string, descriptor ispec.Descriptor) error {
 	if err := e.ensureTempDir(); err != nil {
 		return errors.Wrap(err, "ensure tempdir")
 	}
@@ -276,24 +276,24 @@ func (e *dirEngine) GetBlob(ctx context.Context, digest digest.Digest) (io.ReadC
 
 // GetReference returns a reference from the image. Returns os.ErrNotExist
 // if the name was not found.
-func (e *dirEngine) GetReference(ctx context.Context, name string) (*ispec.Descriptor, error) {
+func (e *dirEngine) GetReference(ctx context.Context, name string) (ispec.Descriptor, error) {
 	path, err := refPath(name)
 	if err != nil {
-		return nil, errors.Wrap(err, "compute ref path")
+		return ispec.Descriptor{}, errors.Wrap(err, "compute ref path")
 	}
 
 	content, err := ioutil.ReadFile(filepath.Join(e.path, path))
 	if err != nil {
-		return nil, errors.Wrap(err, "read ref")
+		return ispec.Descriptor{}, errors.Wrap(err, "read ref")
 	}
 
 	var descriptor ispec.Descriptor
 	if err := json.Unmarshal(content, &descriptor); err != nil {
-		return nil, errors.Wrap(err, "parse ref")
+		return ispec.Descriptor{}, errors.Wrap(err, "parse ref")
 	}
 
 	// XXX: Do we need to validate the descriptor?
-	return &descriptor, nil
+	return descriptor, nil
 }
 
 // DeleteBlob removes a blob from the image. This is idempotent; a nil

--- a/oci/cas/dir_test.go
+++ b/oci/cas/dir_test.go
@@ -299,7 +299,7 @@ func TestEngineReferenceReadonly(t *testing.T) {
 			t.Fatalf("unexpected error opening image: %+v", err)
 		}
 
-		if err := engine.PutReference(ctx, test.name, &test.descriptor); err != nil {
+		if err := engine.PutReference(ctx, test.name, test.descriptor); err != nil {
 			t.Errorf("PutReference: unexpected error: %+v", err)
 		}
 
@@ -320,12 +320,12 @@ func TestEngineReferenceReadonly(t *testing.T) {
 			t.Errorf("GetReference: unexpected error: %+v", err)
 		}
 
-		if !reflect.DeepEqual(test.descriptor, *gotDescriptor) {
+		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
 			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
 		}
 
 		// Make sure that writing will FAIL.
-		if err := newEngine.PutReference(ctx, test.name+"new", &test.descriptor); err == nil {
+		if err := newEngine.PutReference(ctx, test.name+"new", test.descriptor); err == nil {
 			t.Logf("PutReference: e.temp = %s", newEngine.(*dirEngine).temp)
 			t.Errorf("PutReference: expected error on ro image!")
 		}

--- a/oci/cas/gc.go
+++ b/oci/cas/gc.go
@@ -146,7 +146,7 @@ func (gc *gcState) mark(ctx context.Context, descriptor ispec.Descriptor) error 
 	gc.black[descriptor.Digest] = struct{}{}
 
 	// Get the blob to recurse into.
-	blob, err := FromDescriptor(ctx, gc.engine, &descriptor)
+	blob, err := FromDescriptor(ctx, gc.engine, descriptor)
 	if err != nil {
 		return err
 	}
@@ -194,7 +194,7 @@ func GC(ctx context.Context, engine Engine) error {
 			"name":   name,
 			"digest": descriptor.Digest,
 		}).Debugf("GC: got reference")
-		root = append(root, *descriptor)
+		root = append(root, descriptor)
 	}
 
 	// Mark from the root set.


### PR DESCRIPTION
The previous API didn't make much sense, and was quite confusing when
actually trying to use it (nil would always cause errors, and the
intention of the call is not to modify the arguments).

This is part of the preparation of putting oci/cas into an OCI
repository.

Signed-off-by: Aleksa Sarai <asarai@suse.de>