### PR TITLE
contrib: pkg: fix make_spec version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- `umoci` now has some automated scripts for generated RPMs that are used in
+  openSUSE to automatically submit packages to OBS. openSUSE/umoci#101
+
 ### Changed
 - `umoci`'s `oci/cas` and `oci/config` libraries have been massively refactored
   and rewritten, to allow for third-parties to use the OCI libraries. The plan

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ UMOCI_IMAGE := umoci_dev
 VERSION := $(shell cat ./VERSION)
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
-CMD := ./cmd/umoci
+CMD := ${PROJECT}/cmd/umoci
 
 DYN_BUILD_FLAGS := -ldflags "-s -w -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"
 STATIC_BUILD_FLAGS := -ldflags "-s -w -extldflags '-static' -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"

--- a/contrib/pkg/suse/make_spec.sh
+++ b/contrib/pkg/suse/make_spec.sh
@@ -11,7 +11,7 @@ fi
 cd $(dirname $0)
 
 YEAR=$(date +%Y)
-VERSION=$(cat ../../VERSION)
+VERSION=$(cat ../../../VERSION)
 COMMIT_UNIX_TIME=$(git show -s --format=%ct)
 VERSION="${VERSION%+*}+$(date -d @$COMMIT_UNIX_TIME +%Y%m%d).$(git rev-parse --short HEAD)"
 NAME=$1


### PR DESCRIPTION
The version parsing was broken in e4f29ed51033 ("packaging: move to
contrib/pkg"). Also add an entry to the CHANGELOG.

It appears this broke openSUSE's build setup. Since my local developer
environment no longer relies on super-dodgy symlinks I don't mind being
explicit.

Signed-off-by: Aleksa Sarai <asarai@suse.de>