### PR TITLE
test: clean up bundles in tests

### DIFF
--- a/test/config.bats
+++ b/test/config.bats
@@ -21,12 +21,13 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
 @test "umoci config" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -79,8 +80,8 @@ function teardown() {
 }
 
 @test "umoci config --config.user 'user'" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -138,8 +139,8 @@ function teardown() {
 }
 
 @test "umoci config --config.user 'user:group'" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -194,9 +195,9 @@ function teardown() {
 }
 
 @test "umoci config --config.user 'user:group' [parsed from rootfs]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
-	BUNDLE_C="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+	BUNDLE_C="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -276,7 +277,7 @@ function teardown() {
 }
 
 @test "umoci config --config.user 'user:group' [non-existent user]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify the user.
 	umoci config --image "${IMAGE}:${TAG}" --config.user="testuser:emptygroup"
@@ -291,7 +292,7 @@ function teardown() {
 }
 
 @test "umoci config --config.user [numeric]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" --config.user="1337:8888"
@@ -317,7 +318,7 @@ function teardown() {
 }
 
 @test "umoci config --config.workingdir" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" --config.workingdir "/a/fake/directory"
@@ -338,7 +339,7 @@ function teardown() {
 }
 
 @test "umoci config --clear=config.env" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" --clear=config.env
@@ -360,7 +361,7 @@ function teardown() {
 }
 
 @test "umoci config --config.env" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify env.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" --config.env "VARIABLE1=unused"
@@ -395,7 +396,7 @@ function teardown() {
 }
 
 @test "umoci config --config.cmd" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --config.cmd "cat" --config.cmd "/this is a file with spaces" --config.cmd "-v"
@@ -416,7 +417,7 @@ function teardown() {
 }
 
 @test "umoci config --config.[entrypoint+cmd]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --config.entrypoint "sh" --config.cmd "-c" --config.cmd "ls -la"
@@ -438,9 +439,9 @@ function teardown() {
 
 # XXX: This test is somewhat dodgy (since we don't actually set anything other than the destination for a volume).
 @test "umoci config --config.volume" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
-	BUNDLE_C="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+	BUNDLE_C="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --config.volume /volume --config.volume "/some nutty/path name/ here"
@@ -503,7 +504,7 @@ function teardown() {
 }
 
 @test "umoci config --[os+architecture]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	# XXX: We can't test anything other than --os=linux because our generator bails for non-Linux OSes.
@@ -602,7 +603,7 @@ function teardown() {
 }
 
 @test "umoci config --config.label" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" \
@@ -628,7 +629,7 @@ function teardown() {
 }
 
 @test "umoci config --manifest.annotation" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" \
@@ -654,7 +655,7 @@ function teardown() {
 }
 
 @test "umoci config --config.label --manifest.annotation" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" \
@@ -691,7 +692,7 @@ function teardown() {
 # XXX: This is currently not in any spec. So we'll just test our own behaviour
 #      here and we can fix it after opencontainers/image-spec#479 is fixed.
 @test "umoci config --config.label --manifest.annotation [clobber]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" \

--- a/test/create.bats
+++ b/test/create.bats
@@ -21,6 +21,7 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
@@ -31,7 +32,7 @@ function teardown() {
 
 @test "umoci init --layout [empty]" {
 	# Setup up $NEWIMAGE.
-	NEWIMAGE=$(mktemp -d --tmpdir="$BATS_TMPDIR" image-XXXXX)
+	NEWIMAGE="$(setup_tmpdir)"
 	rm -rf "$NEWIMAGE"
 
 	# Create a new image with no tags.
@@ -67,10 +68,10 @@ function teardown() {
 }
 
 @test "umoci new --image" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	# Setup up $NEWIMAGE.
-	export NEWIMAGE=$(mktemp -d --tmpdir="$BATS_TMPDIR" image-XXXXX)
+	NEWIMAGE="$(setup_tmpdir)"
 	rm -rf "$NEWIMAGE"
 
 	# Create a new image with no tags.

--- a/test/gc.bats
+++ b/test/gc.bats
@@ -21,6 +21,7 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
@@ -56,7 +57,7 @@ function teardown() {
 }
 
 @test "umoci gc" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 

--- a/test/pack_mapping.bats
+++ b/test/pack_mapping.bats
@@ -21,6 +21,7 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
@@ -30,8 +31,8 @@ function teardown() {
 
 	image-verify "${IMAGE}"
 
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	# Unpack the image.
 	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "1337:0:65535" --gid-map "8888:0:65535" "$BUNDLE_A"
@@ -78,9 +79,9 @@ function teardown() {
 
 	image-verify "${IMAGE}"
 
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
-	BUNDLE_C="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+	BUNDLE_C="$(setup_tmpdir)"
 
 	# Unpack the image.
 	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "1337:0:65535" --gid-map "7331:0:65535" "$BUNDLE_A"

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -21,12 +21,13 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
 @test "umoci repack" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -101,7 +102,7 @@ function teardown() {
 }
 
 @test "umoci repack [missing args]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
@@ -114,8 +115,8 @@ function teardown() {
 }
 
 @test "umoci repack [whiteout]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -162,8 +163,8 @@ function teardown() {
 }
 
 @test "umoci repack [replace]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -216,7 +217,7 @@ function teardown() {
 }
 
 @test "umoci repack --history.*" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -264,8 +265,8 @@ function teardown() {
 }
 
 @test "umoci {un,re}pack [hardlink]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -323,8 +324,8 @@ function teardown() {
 }
 
 @test "umoci {un,re}pack [unpriv]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -372,9 +373,9 @@ function teardown() {
 }
 
 @test "umoci {un,re}pack [xattrs]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
-	BUNDLE_C="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+	BUNDLE_C="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -444,9 +445,9 @@ function teardown() {
 }
 
 @test "umoci {un,re}pack [unicode]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
-	BUNDLE_C="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+	BUNDLE_C="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 

--- a/test/stat.bats
+++ b/test/stat.bats
@@ -21,6 +21,7 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
@@ -31,7 +32,7 @@ function teardown() {
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
 
-	statFile="$(mktemp --tmpdir="$BATS_TMPDIR" umoci-stat.XXXXXX)"
+	statFile="$(setup_tmpdir)/stat"
 	echo "$output" > "$statFile"
 
 	# .history should have at least one entry.

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -21,6 +21,7 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 

--- a/test/unpack.bats
+++ b/test/unpack.bats
@@ -21,11 +21,12 @@ function setup() {
 }
 
 function teardown() {
+	teardown_tmpdirs
 	teardown_image
 }
 
 @test "umoci unpack" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -64,7 +65,7 @@ function teardown() {
 }
 
 @test "umoci unpack [missing args]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	umoci unpack --image="${IMAGE}:${TAG}"
 	[ "$status" -ne 0 ]
@@ -74,7 +75,7 @@ function teardown() {
 }
 
 @test "umoci unpack [config.json contains mount namespace]" {
-	BUNDLE="$(setup_bundle)"
+	BUNDLE="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 
@@ -92,8 +93,8 @@ function teardown() {
 }
 
 @test "umoci unpack [consistent results]" {
-	BUNDLE_A="$(setup_bundle)"
-	BUNDLE_B="$(setup_bundle)"
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
 
 	image-verify "${IMAGE}"
 


### PR DESCRIPTION
Previously we dropped bundle cleanups because rm(1) is not sophisticated
enough to know how to remove rootless rootfs-es. But this causes issues
with Travis (which has a cap on root filesystem size) so hack around the
rm(1) issues with a chmod 0777 -- which hopefully should handle all of
the important cases.

We have to track everything created with setup_testdir in a separate
manifest file because it turns out that global variables are hard to
modify in bash.

Closes #105 
Signed-off-by: Aleksa Sarai <asarai@suse.de>