### PR TITLE
cmd: add support for --clear=config.{cmd,entrypoint}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `umoci` now has some automated scripts for generated RPMs that are used in
   openSUSE to automatically submit packages to OBS. openSUSE/umoci#101
+- `--clear=config.{cmd,entrypoint}` is now supported. While this interface is a
+  bit weird (`cmd` and `entrypoint` aren't treated atomically) this makes the
+  UX more consistent while we come up with a better `cmd` and `entrypoint` UX.
+  openSUSE/umoci#107
 
 ### Changed
 - `umoci`'s `oci/cas` and `oci/config` libraries have been massively refactored

--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -176,6 +176,16 @@ func config(ctx *cli.Context) error {
 			case "rootfs.diffids":
 				//g.ClearRootfsDiffIDs()
 				return errors.Errorf("--clear=rootfs.diffids is not safe")
+			case "config.cmd":
+				// XXX: This interface is kinda ugly. CMD/ENTRYPOINT are not
+				//      arrays in the same way that any of the other arrays are
+				//      (they're an "atomic" concept).
+				g.SetConfigCmd([]string{})
+			case "config.entrypoint":
+				// XXX: This interface is kinda ugly. CMD/ENTRYPOINT are not
+				//      arrays in the same way that any of the other arrays are
+				//      (they're an "atomic" concept).
+				g.SetConfigEntrypoint([]string{})
 			default:
 				return errors.Errorf("unknown key to --clear: %s", key)
 			}

--- a/man/umoci-config.1.md
+++ b/man/umoci-config.1.md
@@ -78,6 +78,8 @@ The global options are defined in **umoci**(1).
     * manifest.annotations
     * config.exposedports
     * config.env
+    * config.entrypoint
+    * config.cmd
     * config.volume
 
 The following commands all set their corresponding values in the configuration


### PR DESCRIPTION
While the current UX for --config.cmd and --config.entrypoint seems odd
(since they aren't treated atomically, which doesn't make any sense).
But since we're currently treating them like ENV we need to provide a
way to explicitly clear them (even though we clear the old value when
creating a new one).

Reported-by: David Cassany <dcassany@suse.com>
Signed-off-by: Aleksa Sarai <asarai@suse.de>