### PR TITLE
README: reuse the variable for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Follow these steps to build in with [golang](https://golang.org):
 ```bash
 GOPATH=$HOME
 go get -d github.com/openSUSE/umoci
-cd ~/src/github.com/openSUSE/umoci
+cd $GOPATH/github.com/openSUSE/umoci
 make install
 ```
 


### PR DESCRIPTION
Plus for those copying and pasting, if their `$GOPATH` is not `$HOME`
then they will not have to edit that line before pasting.

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>