### PR TITLE
unpack: don't set AdditionalGids in rootless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `umoci` now uses an updated version of `go-mtree`, which has a complete
   rewrite of `Vis` and `Unvis`. The rewrite ensures that unicode handling is
   handled in a far more consistent and sane way. openSUSE/umoci#88
+- `umoci` used to set `process.user.additionalGids` to the "normal value" when
+  unpacking an image in rootless mode, causing issues when trying to actually
+  run said bundle with runC. openSUSE/umoci#109
 
 ## [0.1.0] - 2017-02-11
 ### Added

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -243,6 +243,9 @@ func UnpackManifest(ctx context.Context, engine cas.Engine, bundle string, manif
 func ToRootless(spec *rspec.Spec) {
 	var namespaces []rspec.Namespace
 
+	// Remove additional groups.
+	spec.Process.User.AdditionalGids = nil
+
 	// Remove networkns from the spec.
 	for _, ns := range spec.Linux.Namespaces {
 		switch ns.Type {


### PR DESCRIPTION
We can't join any additional groups as an unprivileged user, so
retaining these groups will always cause failures.

I found this while working on cyphar/orca-build#6.

Signed-off-by: Aleksa Sarai <asarai@suse.de>