### PR TITLE
vendor: update to runtime-spec@v1.0.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- `umoci` now outputs configurations that are compliant with [`v1.0.0-rc5` of
+  the OCI runtime-spec][rspec-v1.0.0-rc5]. This means that now you can use runc
+  v1.0.0-rc3 with `umoci` (and rootless containers should work out of the box
+  if you use a development build of runc). openSUSE/umoci#114
+- `umoci unpack` no longer adds a dummy linux.seccomp entry, and instead just
+  sets it to null. openSUSE/umoci#114
+
+[rspec-v1.0.0-rc5]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc5
 
 ## [0.2.0] - 2017-04-11
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ MAINTAINER "Aleksa Sarai <asarai@suse.com>"
 # into openSUSE:Factory yet.
 RUN zypper ar -f -p 10 -g obs://Virtualization:containers obs-vc && \
     zypper ar -f -p 10 -g obs://devel:languages:go obs-dlg && \
+    zypper ar -f -p 10 -g obs://home:cyphar:containers obs-home-cyphar-containers && \
     zypper ar -f -p 15 -g obs://home:cyphar obs-home-cyphar && \
     zypper ar -f -p 15 -g obs://devel:languages:python3 obs-py3k && \
 	zypper --gpg-auto-import-keys -n ref && \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ install.static: $(GO_SRC)
 .PHONY: update-deps
 update-deps:
 	hack/vendor.sh
-	hack/patch.sh
 
 .PHONY: clean
 clean:

--- a/hack/patch.sh
+++ b/hack/patch.sh
@@ -31,3 +31,6 @@ patch() {
 # project is, so I'm just going to backport it here until I see that there's
 # upstream activity.
 patch github.com/pkg/errors errors-0001-errors-add-Debug-function.patch
+
+# Backport https://github.com/opencontainers/runtime-tools/pull/359.
+patch github.com/opencontainers/runtime-tools runtime-tools-0001-generate-remove-validate-dependency.patch

--- a/hack/runtime-tools-0001-generate-remove-validate-dependency.patch
+++ b/hack/runtime-tools-0001-generate-remove-validate-dependency.patch
@@ -1,0 +1,135 @@
+From cc52997196f8bf7717c5efb5aacd647bc0977282 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Tue, 11 Apr 2017 23:38:02 +1000
+Subject: [PATCH] generate: remove validate dependency
+
+The two modules {validate,generate} should be mutually exclusive and
+should not depend on each other. In addition, it is not the job of
+generate to carry out validation of any arguments provided (especially
+system-specific arguments).
+
+lastCap needs two copies because of the RHEL6 hack, which is a shame but
+does not justify the import dependency (because that dependency pulls in
+logrus and a few other libraries for no good reason).
+
+Fixes: 1a899a6d893e ("validate: optimize capabilites check")
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ generate/generate.go | 27 +++++++++++++++------------
+ validate/validate.go | 13 +++++++------
+ 2 files changed, 22 insertions(+), 18 deletions(-)
+
+diff --git a/generate/generate.go b/generate/generate.go
+index f8a6294ec796..36bb4785d9e3 100644
+--- a/generate/generate.go
++++ b/generate/generate.go
+@@ -11,7 +11,6 @@ import (
+ 
+ 	rspec "github.com/opencontainers/runtime-spec/specs-go"
+ 	"github.com/opencontainers/runtime-tools/generate/seccomp"
+-	"github.com/opencontainers/runtime-tools/validate"
+ 	"github.com/syndtr/gocapability/capability"
+ )
+ 
+@@ -819,12 +818,24 @@ func (g *Generator) AddBindMount(source, dest string, options []string) {
+ 	g.spec.Mounts = append(g.spec.Mounts, mnt)
+ }
+ 
++// lastCap return last cap of system, and is required to hack around RHEL6.
++// This is an exact copy of "validate/validate.go".lastCap.
++func lastCap() capability.Cap {
++	last := capability.CAP_LAST_CAP
++	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
++	if last == capability.Cap(63) {
++		last = capability.CAP_BLOCK_SUSPEND
++	}
++
++	return last
++}
++
+ // SetupPrivileged sets up the privilege-related fields inside g.spec.
+ func (g *Generator) SetupPrivileged(privileged bool) {
+ 	if privileged { // Add all capabilities in privileged mode.
+ 		var finalCapList []string
+ 		for _, cap := range capability.List() {
+-			if g.HostSpecific && cap > validate.LastCap() {
++			if g.HostSpecific && cap > lastCap() {
+ 				continue
+ 			}
+ 			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
+@@ -855,12 +866,8 @@ func (g *Generator) ClearProcessCapabilities() {
+ 
+ // AddProcessCapability adds a process capability into g.spec.Process.Capabilities.
+ func (g *Generator) AddProcessCapability(c string) error {
+-	cp := strings.ToUpper(c)
+-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+-		return err
+-	}
+-
+ 	g.initSpec()
++	cp := strings.ToUpper(c)
+ 
+ 	for _, cap := range g.spec.Process.Capabilities.Bounding {
+ 		if strings.ToUpper(cap) == cp {
+@@ -902,12 +909,8 @@ func (g *Generator) AddProcessCapability(c string) error {
+ 
+ // DropProcessCapability drops a process capability from g.spec.Process.Capabilities.
+ func (g *Generator) DropProcessCapability(c string) error {
+-	cp := strings.ToUpper(c)
+-	if err := validate.CapValid(cp, g.HostSpecific); err != nil {
+-		return err
+-	}
+-
+ 	g.initSpec()
++	cp := strings.ToUpper(c)
+ 
+ 	for i, cap := range g.spec.Process.Capabilities.Bounding {
+ 		if strings.ToUpper(cap) == cp {
+diff --git a/validate/validate.go b/validate/validate.go
+index 76c3ca6a7337..c834815260ae 100644
+--- a/validate/validate.go
++++ b/validate/validate.go
+@@ -312,7 +312,7 @@ func (v *Validator) CheckCapablities() (msgs []string) {
+ 		}
+ 
+ 		for _, capability := range caps {
+-			if err := CapValid(capability, v.HostSpecific); err != nil {
++			if err := capValid(capability, v.HostSpecific); err != nil {
+ 				msgs = append(msgs, fmt.Sprintf("capability %q is not valid, man capabilities(7)", capability))
+ 			}
+ 		}
+@@ -614,8 +614,8 @@ func (v *Validator) CheckSeccomp() (msgs []string) {
+ 	return
+ }
+ 
+-// CapValid checks whether a capability is valid
+-func CapValid(c string, hostSpecific bool) error {
++// capValid checks whether a capability is valid
++func capValid(c string, hostSpecific bool) error {
+ 	isValid := false
+ 
+ 	if !strings.HasPrefix(c, "CAP_") {
+@@ -623,7 +623,7 @@ func CapValid(c string, hostSpecific bool) error {
+ 	}
+ 	for _, cap := range capability.List() {
+ 		if c == fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())) {
+-			if hostSpecific && cap > LastCap() {
++			if hostSpecific && cap > lastCap() {
+ 				return fmt.Errorf("CAP_%s is not supported on the current host", c)
+ 			}
+ 			isValid = true
+@@ -637,8 +637,9 @@ func CapValid(c string, hostSpecific bool) error {
+ 	return nil
+ }
+ 
+-// LastCap return last cap of system
+-func LastCap() capability.Cap {
++// lastCap return last cap of system, and is required to hack around RHEL6.
++// This is an exact copy of "generate/generate.go".lastCap.
++func lastCap() capability.Cap {
+ 	last := capability.CAP_LAST_CAP
+ 	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
+ 	if last == capability.Cap(63) {
+-- 
+2.12.2
+

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -118,9 +118,9 @@ clone() {
 #       with LK4D4/vndr). This setup is a bit unwieldy.
 clone github.com/opencontainers/go-digest v1.0.0-rc0
 clone github.com/opencontainers/image-spec v1.0.0-rc4
-clone github.com/opencontainers/runtime-spec v1.0.0-rc2
+clone github.com/opencontainers/runtime-spec v1.0.0-rc5
 clone github.com/opencontainers/image-tools 421458f7e467ac86175408693a07da6d29817bf7
-clone github.com/opencontainers/runtime-tools b61b44a71dafb8472bbc1e5eb0d68ed9ce8ba6ac
+clone github.com/opencontainers/runtime-tools 2f0b832c731dcacc6ad44b03200a3a6a3e14393e
 clone github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 clone golang.org/x/crypto b8a2a83acfe6e6770b75de42d5ff4c67596675c0 https://github.com/golang/crypto
 clone golang.org/x/sys d75a52659825e75fff6158388dddc6a5b04f9ba5 https://github.com/golang/sys

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -107,10 +107,10 @@ clone() {
 	set -e
 	(
 		rm -rf "$vendorPath" && mkdir -p "$vendorPath"
-		git clone "$cloneURL" "$vendorPath" &>/dev/null
+		git clone "$cloneURL" "$vendorPath"
 		cd "$vendorPath"
-		git checkout --detach "$commit" &>/dev/null
-	)
+		git checkout --detach "$commit"
+	) &>/dev/null
 }
 
 # Update everything.
@@ -130,6 +130,10 @@ clone github.com/apex/log afb2e76037a5f36542c77e88ef8aef9f469b09f8
 clone github.com/urfave/cli v1.18.1
 clone github.com/vbatts/go-mtree 711a89aa4c4a8f148d87eb915456eba8ee7c6a0b
 clone golang.org/x/net 45e771701b814666a7eb299e6c7a57d0b1799e91 https://github.com/golang/net
+
+# Apply patches.
+self="$(readlink -f "$(dirname "${BASH_SOURCE}")")"
+$self/patch.sh
 
 # Clean up the vendor directory.
 clean

--- a/oci/config/convert/runtime.go
+++ b/oci/config/convert/runtime.go
@@ -148,5 +148,8 @@ func MutateRuntimeSpec(g rgen.Generator, rootfs string, image ispec.Image, manif
 		g.AddAnnotation(key, value)
 	}
 
+	// Remove all seccomp rules.
+	g.Spec().Linux.Seccomp = nil
+
 	return nil
 }

--- a/oci/layer/tar_extract_test.go
+++ b/oci/layer/tar_extract_test.go
@@ -471,12 +471,12 @@ func TestUnpackEntryMap(t *testing.T) {
 	// TODO: Modify this to use subtests once Go 1.7 is in enough places.
 	func(t *testing.T) {
 		for _, test := range []struct {
-			uidMap rspec.IDMapping
-			gidMap rspec.IDMapping
+			uidMap rspec.LinuxIDMapping
+			gidMap rspec.LinuxIDMapping
 		}{
-			{rspec.IDMapping{HostID: 0, ContainerID: 0, Size: 100}, rspec.IDMapping{HostID: 0, ContainerID: 0, Size: 100}},
-			{rspec.IDMapping{HostID: uint32(os.Getuid()), ContainerID: 0, Size: 100}, rspec.IDMapping{HostID: uint32(os.Getgid()), ContainerID: 0, Size: 100}},
-			{rspec.IDMapping{HostID: uint32(os.Getuid() + 100), ContainerID: 0, Size: 100}, rspec.IDMapping{HostID: uint32(os.Getgid() + 200), ContainerID: 0, Size: 100}},
+			{rspec.LinuxIDMapping{HostID: 0, ContainerID: 0, Size: 100}, rspec.LinuxIDMapping{HostID: 0, ContainerID: 0, Size: 100}},
+			{rspec.LinuxIDMapping{HostID: uint32(os.Getuid()), ContainerID: 0, Size: 100}, rspec.LinuxIDMapping{HostID: uint32(os.Getgid()), ContainerID: 0, Size: 100}},
+			{rspec.LinuxIDMapping{HostID: uint32(os.Getuid() + 100), ContainerID: 0, Size: 100}, rspec.LinuxIDMapping{HostID: uint32(os.Getgid() + 200), ContainerID: 0, Size: 100}},
 		} {
 			// Create the files we're going to play with.
 			dir, err := ioutil.TempDir("", "umoci-TestUnpackEntryMap")
@@ -499,8 +499,8 @@ func TestUnpackEntryMap(t *testing.T) {
 			)
 
 			te := newTarExtractor(MapOptions{
-				UIDMappings: []rspec.IDMapping{test.uidMap},
-				GIDMappings: []rspec.IDMapping{test.gidMap},
+				UIDMappings: []rspec.LinuxIDMapping{test.uidMap},
+				GIDMappings: []rspec.LinuxIDMapping{test.gidMap},
 			})
 
 			// Regular file.

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -281,7 +281,7 @@ func UnpackRuntimeJSON(ctx context.Context, engine cas.Engine, configFile io.Wri
 // containers. This is done by removing options and other settings that clash
 // with unprivileged user namespaces.
 func ToRootless(spec *rspec.Spec) {
-	var namespaces []rspec.Namespace
+	var namespaces []rspec.LinuxNamespace
 
 	// Remove additional groups.
 	spec.Process.User.AdditionalGids = nil
@@ -296,7 +296,7 @@ func ToRootless(spec *rspec.Spec) {
 		}
 	}
 	// Add userns to the spec.
-	namespaces = append(namespaces, rspec.Namespace{
+	namespaces = append(namespaces, rspec.LinuxNamespace{
 		Type: rspec.UserNamespace,
 	})
 	spec.Linux.Namespaces = namespaces

--- a/oci/layer/utils.go
+++ b/oci/layer/utils.go
@@ -32,8 +32,8 @@ import (
 type MapOptions struct {
 	// UIDMappings and GIDMappings are the UID and GID mappings to apply when
 	// packing and unpacking image rootfs layers.
-	UIDMappings []rspec.IDMapping `json:"uid_mappings"`
-	GIDMappings []rspec.IDMapping `json:"gid_mappings"`
+	UIDMappings []rspec.LinuxIDMapping `json:"uid_mappings"`
+	GIDMappings []rspec.LinuxIDMapping `json:"gid_mappings"`
 
 	// Rootless specifies whether any to error out if chown fails.
 	Rootless bool `json:"rootless"`

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -28,7 +28,7 @@ import (
 // ToHost translates a remapped container ID to an unmapped host ID using the
 // provided ID mapping. If no mapping is provided, then the mapping is a no-op.
 // If there is no mapping for the given ID an error is returned.
-func ToHost(contID int, idMap []rspec.IDMapping) (int, error) {
+func ToHost(contID int, idMap []rspec.LinuxIDMapping) (int, error) {
 	if idMap == nil {
 		return contID, nil
 	}
@@ -46,7 +46,7 @@ func ToHost(contID int, idMap []rspec.IDMapping) (int, error) {
 // container ID using the provided ID mapping. If no mapping is provided, then
 // the mapping is a no-op. If there is no mapping for the given ID an error is
 // returned.
-func ToContainer(hostID int, idMap []rspec.IDMapping) (int, error) {
+func ToContainer(hostID int, idMap []rspec.LinuxIDMapping) (int, error) {
 	if idMap == nil {
 		return hostID, nil
 	}
@@ -61,9 +61,9 @@ func ToContainer(hostID int, idMap []rspec.IDMapping) (int, error) {
 }
 
 // ParseMapping takes a mapping string of the form "host:container[:size]" and
-// returns the corresponding rspec.IDMapping. An error is returned if not
+// returns the corresponding rspec.LinuxIDMapping. An error is returned if not
 // enough fields are provided or are otherwise invalid. The default size is 1.
-func ParseMapping(spec string) (rspec.IDMapping, error) {
+func ParseMapping(spec string) (rspec.LinuxIDMapping, error) {
 	parts := strings.Split(spec, ":")
 
 	var err error
@@ -72,25 +72,25 @@ func ParseMapping(spec string) (rspec.IDMapping, error) {
 	case 3:
 		size, err = strconv.Atoi(parts[2])
 		if err != nil {
-			return rspec.IDMapping{}, errors.Wrap(err, "invalid size in mapping")
+			return rspec.LinuxIDMapping{}, errors.Wrap(err, "invalid size in mapping")
 		}
 	case 2:
 		size = 1
 	default:
-		return rspec.IDMapping{}, errors.Errorf("invalid number of fields in mapping '%s': %d", spec, len(parts))
+		return rspec.LinuxIDMapping{}, errors.Errorf("invalid number of fields in mapping '%s': %d", spec, len(parts))
 	}
 
 	hostID, err = strconv.Atoi(parts[0])
 	if err != nil {
-		return rspec.IDMapping{}, errors.Wrap(err, "invalid hostID in mapping")
+		return rspec.LinuxIDMapping{}, errors.Wrap(err, "invalid hostID in mapping")
 	}
 
 	contID, err = strconv.Atoi(parts[1])
 	if err != nil {
-		return rspec.IDMapping{}, errors.Wrap(err, "invalid containerID in mapping")
+		return rspec.LinuxIDMapping{}, errors.Wrap(err, "invalid containerID in mapping")
 	}
 
-	return rspec.IDMapping{
+	return rspec.LinuxIDMapping{
 		HostID:      uint32(hostID),
 		ContainerID: uint32(contID),
 		Size:        uint32(size),

--- a/pkg/idtools/idtools_test.go
+++ b/pkg/idtools/idtools_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestToHost(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      1337,
 			ContainerID: 0,
@@ -74,7 +74,7 @@ func TestToHostNil(t *testing.T) {
 }
 
 func TestToHostLarger(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      8000,
 			ContainerID: 0,
@@ -109,7 +109,7 @@ func TestToHostLarger(t *testing.T) {
 }
 
 func TestToHostMultiple(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      2222,
 			ContainerID: 0,
@@ -157,7 +157,7 @@ func TestToHostMultiple(t *testing.T) {
 }
 
 func TestToContainer(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      1337,
 			ContainerID: 0,
@@ -207,7 +207,7 @@ func TestToContainerNil(t *testing.T) {
 }
 
 func TestToContainerLarger(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      8000,
 			ContainerID: 0,
@@ -242,7 +242,7 @@ func TestToContainerLarger(t *testing.T) {
 }
 
 func TestToContainerMultiple(t *testing.T) {
-	idMap := []rspec.IDMapping{
+	idMap := []rspec.LinuxIDMapping{
 		{
 			HostID:      2222,
 			ContainerID: 0,

--- a/test/raw-config.bats
+++ b/test/raw-config.bats
@@ -34,7 +34,6 @@ function teardown() {
 	# Unpack the image.
 	umoci raw runtime-config --image "${IMAGE}:${TAG}" "$BUNDLE_A/config.json"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_A"
 
 	# We need to make sure the config exists.
 	[ -f "$BUNDLE_A/config.json" ]
@@ -47,7 +46,6 @@ function teardown() {
 	# Unpack the image again.
 	umoci raw runtime-config --image "${IMAGE}:${TAG}-new" "$BUNDLE_B/config.json"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_B"
 
 	# Make sure that the config was unchanged.
 	# First clean the config.
@@ -466,7 +464,6 @@ function teardown() {
 	# Unpack the image again.
 	umoci raw runtime-config --image "${IMAGE}:${TAG}" "$BUNDLE_A/config.json"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_A"
 
 	# Get set of mounts
 	sane_run jq -SMr '.mounts[] | .destination' "$BUNDLE_A/config.json"

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -17,7 +17,7 @@ type Spec struct {
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.
-	Hooks Hooks `json:"hooks"`
+	Hooks *Hooks `json:"hooks,omitempty"`
 	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
@@ -25,12 +25,16 @@ type Spec struct {
 	Linux *Linux `json:"linux,omitempty" platform:"linux"`
 	// Solaris is platform specific configuration for Solaris containers.
 	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
+	// Windows is platform specific configuration for Windows based containers, including Hyper-V containers.
+	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
 // Process contains information to start a specific application inside the container.
 type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
+	// ConsoleSize specifies the size of the console.
+	ConsoleSize Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -40,28 +44,51 @@ type Process struct {
 	// Cwd is the current working directory for the process and must be
 	// relative to the container's root.
 	Cwd string `json:"cwd"`
-	// Capabilities are Linux capabilities that are kept for the container.
-	Capabilities []string `json:"capabilities,omitempty" platform:"linux"`
+	// Capabilities are Linux capabilities that are kept for the process.
+	Capabilities *LinuxCapabilities `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []Rlimit `json:"rlimits,omitempty"`
+	Rlimits []LinuxRlimit `json:"rlimits,omitempty" platform:"linux"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
-	NoNewPrivileges bool `json:"noNewPrivileges,omitempty"`
-
-	// ApparmorProfile specifies the apparmor profile for the container. (this field is platform dependent)
+	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
+	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
-	// SelinuxLabel specifies the selinux context that the container process is run as. (this field is platform dependent)
+	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
 
-// User specifies Linux/Solaris specific user and group information
-// for the container process.
+// LinuxCapabilities specifies the whitelist of capabilities that are kept for a process.
+// http://man7.org/linux/man-pages/man7/capabilities.7.html
+type LinuxCapabilities struct {
+	// Bounding is the set of capabilities checked by the kernel.
+	Bounding []string `json:"bounding,omitempty" platform:"linux"`
+	// Effective is the set of capabilities checked by the kernel.
+	Effective []string `json:"effective,omitempty" platform:"linux"`
+	// Inheritable is the capabilities preserved across execve.
+	Inheritable []string `json:"inheritable,omitempty" platform:"linux"`
+	// Permitted is the limiting superset for effective capabilities.
+	Permitted []string `json:"permitted,omitempty" platform:"linux"`
+	// Ambient is the ambient set of capabilities that are kept.
+	Ambient []string `json:"ambient,omitempty" platform:"linux"`
+}
+
+// Box specifies dimensions of a rectangle. Used for specifying the size of a console.
+type Box struct {
+	// Height is the vertical dimension of a box.
+	Height uint `json:"height"`
+	// Width is the horizontal dimension of a box.
+	Width uint `json:"width"`
+}
+
+// User specifies specific user (and group) information for the container process.
 type User struct {
-	// UID is the user id. (this field is platform dependent)
+	// UID is the user id.
 	UID uint32 `json:"uid" platform:"linux,solaris"`
-	// GID is the group id. (this field is platform dependent)
+	// GID is the group id.
 	GID uint32 `json:"gid" platform:"linux,solaris"`
-	// AdditionalGids are additional group ids set for the container's process. (this field is platform dependent)
+	// AdditionalGids are additional group ids set for the container's process.
 	AdditionalGids []uint32 `json:"additionalGids,omitempty" platform:"linux,solaris"`
+	// Username is the user name.
+	Username string `json:"username,omitempty" platform:"windows"`
 }
 
 // Root contains information about the container's root filesystem on the host.
@@ -86,10 +113,10 @@ type Mount struct {
 	// Destination is the path where the mount will be placed relative to the container's root.  The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
 	Destination string `json:"destination"`
 	// Type specifies the mount kind.
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 	// Source specifies the source path of the mount.  In the case of bind mounts on
 	// Linux based systems this would be the file on the host.
-	Source string `json:"source"`
+	Source string `json:"source,omitempty"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
 }
@@ -116,24 +143,24 @@ type Hooks struct {
 // Linux contains platform specific configuration for Linux based containers.
 type Linux struct {
 	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
-	UIDMappings []IDMapping `json:"uidMappings,omitempty"`
+	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
 	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
-	GIDMappings []IDMapping `json:"gidMappings,omitempty"`
+	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty"`
 	// Sysctl are a set of key value pairs that are set for the container on start
 	Sysctl map[string]string `json:"sysctl,omitempty"`
 	// Resources contain cgroup information for handling resource constraints
 	// for the container
-	Resources *Resources `json:"resources,omitempty"`
+	Resources *LinuxResources `json:"resources,omitempty"`
 	// CgroupsPath specifies the path to cgroups that are created and/or joined by the container.
 	// The path is expected to be relative to the cgroups mountpoint.
 	// If resources are specified, the cgroups at CgroupsPath will be updated based on resources.
-	CgroupsPath *string `json:"cgroupsPath,omitempty"`
+	CgroupsPath string `json:"cgroupsPath,omitempty"`
 	// Namespaces contains the namespaces that are created and/or joined by the container
-	Namespaces []Namespace `json:"namespaces,omitempty"`
+	Namespaces []LinuxNamespace `json:"namespaces,omitempty"`
 	// Devices are a list of device nodes that are created for the container
-	Devices []Device `json:"devices,omitempty"`
+	Devices []LinuxDevice `json:"devices,omitempty"`
 	// Seccomp specifies the seccomp security settings for the container.
-	Seccomp *Seccomp `json:"seccomp,omitempty"`
+	Seccomp *LinuxSeccomp `json:"seccomp,omitempty"`
 	// RootfsPropagation is the rootfs mount propagation mode for the container.
 	RootfsPropagation string `json:"rootfsPropagation,omitempty"`
 	// MaskedPaths masks over the provided paths inside the container.
@@ -144,21 +171,21 @@ type Linux struct {
 	MountLabel string `json:"mountLabel,omitempty"`
 }
 
-// Namespace is the configuration for a Linux namespace
-type Namespace struct {
+// LinuxNamespace is the configuration for a Linux namespace
+type LinuxNamespace struct {
 	// Type is the type of Linux namespace
-	Type NamespaceType `json:"type"`
+	Type LinuxNamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
 	Path string `json:"path,omitempty"`
 }
 
-// NamespaceType is one of the Linux namespaces
-type NamespaceType string
+// LinuxNamespaceType is one of the Linux namespaces
+type LinuxNamespaceType string
 
 const (
 	// PIDNamespace for isolating process IDs
-	PIDNamespace NamespaceType = "pid"
+	PIDNamespace LinuxNamespaceType = "pid"
 	// NetworkNamespace for isolating network devices, stacks, ports, etc
 	NetworkNamespace = "network"
 	// MountNamespace for isolating mount points
@@ -173,18 +200,18 @@ const (
 	CgroupNamespace = "cgroup"
 )
 
-// IDMapping specifies UID/GID mappings
-type IDMapping struct {
-	// HostID is the UID/GID of the host user or group
+// LinuxIDMapping specifies UID/GID mappings
+type LinuxIDMapping struct {
+	// HostID is the starting UID/GID on the host to be mapped to 'ContainerID'
 	HostID uint32 `json:"hostID"`
-	// ContainerID is the UID/GID of the container's user or group
+	// ContainerID is the starting UID/GID in the container
 	ContainerID uint32 `json:"containerID"`
-	// Size is the length of the range of IDs mapped between the two namespaces
+	// Size is the number of IDs to be mapped
 	Size uint32 `json:"size"`
 }
 
-// Rlimit type and restrictions
-type Rlimit struct {
+// LinuxRlimit type and restrictions
+type LinuxRlimit struct {
 	// Type of the rlimit to set
 	Type string `json:"type"`
 	// Hard is the hard limit for the specified type
@@ -193,66 +220,66 @@ type Rlimit struct {
 	Soft uint64 `json:"soft"`
 }
 
-// HugepageLimit structure corresponds to limiting kernel hugepages
-type HugepageLimit struct {
+// LinuxHugepageLimit structure corresponds to limiting kernel hugepages
+type LinuxHugepageLimit struct {
 	// Pagesize is the hugepage size
-	Pagesize *string `json:"pageSize,omitempty"`
+	Pagesize string `json:"pageSize"`
 	// Limit is the limit of "hugepagesize" hugetlb usage
-	Limit *uint64 `json:"limit,omitempty"`
+	Limit uint64 `json:"limit"`
 }
 
-// InterfacePriority for network interfaces
-type InterfacePriority struct {
+// LinuxInterfacePriority for network interfaces
+type LinuxInterfacePriority struct {
 	// Name is the name of the network interface
 	Name string `json:"name"`
 	// Priority for the interface
 	Priority uint32 `json:"priority"`
 }
 
-// blockIODevice holds major:minor format supported in blkio cgroup
-type blockIODevice struct {
+// linuxBlockIODevice holds major:minor format supported in blkio cgroup
+type linuxBlockIODevice struct {
 	// Major is the device's major number.
 	Major int64 `json:"major"`
 	// Minor is the device's minor number.
 	Minor int64 `json:"minor"`
 }
 
-// WeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
-type WeightDevice struct {
-	blockIODevice
+// LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+type LinuxWeightDevice struct {
+	linuxBlockIODevice
 	// Weight is the bandwidth rate for the device, range is from 10 to 1000
 	Weight *uint16 `json:"weight,omitempty"`
 	// LeafWeight is the bandwidth rate for the device while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
 	LeafWeight *uint16 `json:"leafWeight,omitempty"`
 }
 
-// ThrottleDevice struct holds a `major:minor rate_per_second` pair
-type ThrottleDevice struct {
-	blockIODevice
+// LinuxThrottleDevice struct holds a `major:minor rate_per_second` pair
+type LinuxThrottleDevice struct {
+	linuxBlockIODevice
 	// Rate is the IO rate limit per cgroup per device
-	Rate *uint64 `json:"rate,omitempty"`
+	Rate uint64 `json:"rate"`
 }
 
-// BlockIO for Linux cgroup 'blkio' resource management
-type BlockIO struct {
+// LinuxBlockIO for Linux cgroup 'blkio' resource management
+type LinuxBlockIO struct {
 	// Specifies per cgroup weight, range is from 10 to 1000
 	Weight *uint16 `json:"blkioWeight,omitempty"`
 	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, range is from 10 to 1000, CFQ scheduler only
 	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
 	// Weight per cgroup per device, can override BlkioWeight
-	WeightDevice []WeightDevice `json:"blkioWeightDevice,omitempty"`
+	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
 	// IO read rate limit per cgroup per device, bytes per second
-	ThrottleReadBpsDevice []ThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
 	// IO write rate limit per cgroup per device, bytes per second
-	ThrottleWriteBpsDevice []ThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
 	// IO read rate limit per cgroup per device, IO per second
-	ThrottleReadIOPSDevice []ThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
 	// IO write rate limit per cgroup per device, IO per second
-	ThrottleWriteIOPSDevice []ThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
 }
 
-// Memory for Linux cgroup 'memory' resource management
-type Memory struct {
+// LinuxMemory for Linux cgroup 'memory' resource management
+type LinuxMemory struct {
 	// Memory limit (in bytes).
 	Limit *uint64 `json:"limit,omitempty"`
 	// Memory reservation or soft_limit (in bytes).
@@ -267,62 +294,62 @@ type Memory struct {
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
 
-// CPU for Linux cgroup 'cpu' resource management
-type CPU struct {
+// LinuxCPU for Linux cgroup 'cpu' resource management
+type LinuxCPU struct {
 	// CPU shares (relative weight (ratio) vs. other cgroups with cpu shares).
 	Shares *uint64 `json:"shares,omitempty"`
 	// CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	Quota *uint64 `json:"quota,omitempty"`
+	Quota *int64 `json:"quota,omitempty"`
 	// CPU period to be used for hardcapping (in usecs).
 	Period *uint64 `json:"period,omitempty"`
 	// How much time realtime scheduling may use (in usecs).
-	RealtimeRuntime *uint64 `json:"realtimeRuntime,omitempty"`
+	RealtimeRuntime *int64 `json:"realtimeRuntime,omitempty"`
 	// CPU period to be used for realtime scheduling (in usecs).
 	RealtimePeriod *uint64 `json:"realtimePeriod,omitempty"`
 	// CPUs to use within the cpuset. Default is to use any CPU available.
-	Cpus *string `json:"cpus,omitempty"`
+	Cpus string `json:"cpus,omitempty"`
 	// List of memory nodes in the cpuset. Default is to use any available memory node.
-	Mems *string `json:"mems,omitempty"`
+	Mems string `json:"mems,omitempty"`
 }
 
-// Pids for Linux cgroup 'pids' resource management (Linux 4.3)
-type Pids struct {
+// LinuxPids for Linux cgroup 'pids' resource management (Linux 4.3)
+type LinuxPids struct {
 	// Maximum number of PIDs. Default is "no limit".
-	Limit *int64 `json:"limit,omitempty"`
+	Limit int64 `json:"limit"`
 }
 
-// Network identification and priority configuration
-type Network struct {
+// LinuxNetwork identification and priority configuration
+type LinuxNetwork struct {
 	// Set class identifier for container's network packets
 	ClassID *uint32 `json:"classID,omitempty"`
 	// Set priority of network traffic for container
-	Priorities []InterfacePriority `json:"priorities,omitempty"`
+	Priorities []LinuxInterfacePriority `json:"priorities,omitempty"`
 }
 
-// Resources has container runtime resource constraints
-type Resources struct {
+// LinuxResources has container runtime resource constraints
+type LinuxResources struct {
 	// Devices configures the device whitelist.
-	Devices []DeviceCgroup `json:"devices,omitempty"`
+	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Specify an oom_score_adj for the container.
 	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// Memory restriction configuration
-	Memory *Memory `json:"memory,omitempty"`
+	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration
-	CPU *CPU `json:"cpu,omitempty"`
+	CPU *LinuxCPU `json:"cpu,omitempty"`
 	// Task resource restriction configuration.
-	Pids *Pids `json:"pids,omitempty"`
+	Pids *LinuxPids `json:"pids,omitempty"`
 	// BlockIO restriction configuration
-	BlockIO *BlockIO `json:"blockIO,omitempty"`
+	BlockIO *LinuxBlockIO `json:"blockIO,omitempty"`
 	// Hugetlb limit (in bytes)
-	HugepageLimits []HugepageLimit `json:"hugepageLimits,omitempty"`
+	HugepageLimits []LinuxHugepageLimit `json:"hugepageLimits,omitempty"`
 	// Network restriction configuration
-	Network *Network `json:"network,omitempty"`
+	Network *LinuxNetwork `json:"network,omitempty"`
 }
 
-// Device represents the mknod information for a Linux special device file
-type Device struct {
+// LinuxDevice represents the mknod information for a Linux special device file
+type LinuxDevice struct {
 	// Path to the device.
 	Path string `json:"path"`
 	// Device type, block, char, etc.
@@ -339,25 +366,18 @@ type Device struct {
 	GID *uint32 `json:"gid,omitempty"`
 }
 
-// DeviceCgroup represents a device rule for the whitelist controller
-type DeviceCgroup struct {
+// LinuxDeviceCgroup represents a device rule for the whitelist controller
+type LinuxDeviceCgroup struct {
 	// Allow or deny
 	Allow bool `json:"allow"`
 	// Device type, block, char, etc.
-	Type *string `json:"type,omitempty"`
+	Type string `json:"type,omitempty"`
 	// Major is the device's major number.
 	Major *int64 `json:"major,omitempty"`
 	// Minor is the device's minor number.
 	Minor *int64 `json:"minor,omitempty"`
 	// Cgroup access permissions format, rwm.
-	Access *string `json:"access,omitempty"`
-}
-
-// Seccomp represents syscall restrictions
-type Seccomp struct {
-	DefaultAction Action    `json:"defaultAction"`
-	Architectures []Arch    `json:"architectures"`
-	Syscalls      []Syscall `json:"syscalls,omitempty"`
+	Access string `json:"access,omitempty"`
 }
 
 // Solaris contains platform specific configuration for Solaris application containers.
@@ -369,26 +389,26 @@ type Solaris struct {
 	// The maximum amount of shared memory allowed for this container.
 	MaxShmMemory string `json:"maxShmMemory,omitempty"`
 	// Specification for automatic creation of network resources for this container.
-	Anet []Anet `json:"anet,omitempty"`
+	Anet []SolarisAnet `json:"anet,omitempty"`
 	// Set limit on the amount of CPU time that can be used by container.
-	CappedCPU *CappedCPU `json:"cappedCPU,omitempty"`
+	CappedCPU *SolarisCappedCPU `json:"cappedCPU,omitempty"`
 	// The physical and swap caps on the memory that can be used by this container.
-	CappedMemory *CappedMemory `json:"cappedMemory,omitempty"`
+	CappedMemory *SolarisCappedMemory `json:"cappedMemory,omitempty"`
 }
 
-// CappedCPU allows users to set limit on the amount of CPU time that can be used by container.
-type CappedCPU struct {
+// SolarisCappedCPU allows users to set limit on the amount of CPU time that can be used by container.
+type SolarisCappedCPU struct {
 	Ncpus string `json:"ncpus,omitempty"`
 }
 
-// CappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
-type CappedMemory struct {
+// SolarisCappedMemory allows users to set the physical and swap caps on the memory that can be used by this container.
+type SolarisCappedMemory struct {
 	Physical string `json:"physical,omitempty"`
 	Swap     string `json:"swap,omitempty"`
 }
 
-// Anet provides the specification for automatic creation of network resources for this container.
-type Anet struct {
+// SolarisAnet provides the specification for automatic creation of network resources for this container.
+type SolarisAnet struct {
 	// Specify a name for the automatically created VNIC datalink.
 	Linkname string `json:"linkname,omitempty"`
 	// Specify the link over which the VNIC will be created.
@@ -403,6 +423,65 @@ type Anet struct {
 	Linkprotection string `json:"linkProtection,omitempty"`
 	// Set the VNIC's macAddress
 	Macaddress string `json:"macAddress,omitempty"`
+}
+
+// Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
+type Windows struct {
+	// Resources contains information for handling resource constraints for the container.
+	Resources *WindowsResources `json:"resources,omitempty"`
+}
+
+// WindowsResources has container runtime resource constraints for containers running on Windows.
+type WindowsResources struct {
+	// Memory restriction configuration.
+	Memory *WindowsMemoryResources `json:"memory,omitempty"`
+	// CPU resource restriction configuration.
+	CPU *WindowsCPUResources `json:"cpu,omitempty"`
+	// Storage restriction configuration.
+	Storage *WindowsStorageResources `json:"storage,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetworkResources `json:"network,omitempty"`
+}
+
+// WindowsMemoryResources contains memory resource management settings.
+type WindowsMemoryResources struct {
+	// Memory limit in bytes.
+	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation in bytes.
+	Reservation *uint64 `json:"reservation,omitempty"`
+}
+
+// WindowsCPUResources contains CPU resource management settings.
+type WindowsCPUResources struct {
+	// Number of CPUs available to the container.
+	Count *uint64 `json:"count,omitempty"`
+	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
+	Shares *uint16 `json:"shares,omitempty"`
+	// Percent of available CPUs usable by the container.
+	Percent *uint8 `json:"percent,omitempty"`
+}
+
+// WindowsStorageResources contains storage resource management settings.
+type WindowsStorageResources struct {
+	// Specifies maximum Iops for the system drive.
+	Iops *uint64 `json:"iops,omitempty"`
+	// Specifies maximum bytes per second for the system drive.
+	Bps *uint64 `json:"bps,omitempty"`
+	// Sandbox size specifies the minimum size of the system drive in bytes.
+	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
+}
+
+// WindowsNetworkResources contains network resource management settings.
+type WindowsNetworkResources struct {
+	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
+	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+}
+
+// LinuxSeccomp represents syscall restrictions
+type LinuxSeccomp struct {
+	DefaultAction LinuxSeccompAction `json:"defaultAction"`
+	Architectures []Arch             `json:"architectures,omitempty"`
+	Syscalls      []LinuxSyscall     `json:"syscalls"`
 }
 
 // Arch used for additional architectures
@@ -427,45 +506,48 @@ const (
 	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
 	ArchS390        Arch = "SCMP_ARCH_S390"
 	ArchS390X       Arch = "SCMP_ARCH_S390X"
+	ArchPARISC      Arch = "SCMP_ARCH_PARISC"
+	ArchPARISC64    Arch = "SCMP_ARCH_PARISC64"
 )
 
-// Action taken upon Seccomp rule match
-type Action string
+// LinuxSeccompAction taken upon Seccomp rule match
+type LinuxSeccompAction string
 
 // Define actions for Seccomp rules
 const (
-	ActKill  Action = "SCMP_ACT_KILL"
-	ActTrap  Action = "SCMP_ACT_TRAP"
-	ActErrno Action = "SCMP_ACT_ERRNO"
-	ActTrace Action = "SCMP_ACT_TRACE"
-	ActAllow Action = "SCMP_ACT_ALLOW"
+	ActKill  LinuxSeccompAction = "SCMP_ACT_KILL"
+	ActTrap  LinuxSeccompAction = "SCMP_ACT_TRAP"
+	ActErrno LinuxSeccompAction = "SCMP_ACT_ERRNO"
+	ActTrace LinuxSeccompAction = "SCMP_ACT_TRACE"
+	ActAllow LinuxSeccompAction = "SCMP_ACT_ALLOW"
 )
 
-// Operator used to match syscall arguments in Seccomp
-type Operator string
+// LinuxSeccompOperator used to match syscall arguments in Seccomp
+type LinuxSeccompOperator string
 
 // Define operators for syscall arguments in Seccomp
 const (
-	OpNotEqual     Operator = "SCMP_CMP_NE"
-	OpLessThan     Operator = "SCMP_CMP_LT"
-	OpLessEqual    Operator = "SCMP_CMP_LE"
-	OpEqualTo      Operator = "SCMP_CMP_EQ"
-	OpGreaterEqual Operator = "SCMP_CMP_GE"
-	OpGreaterThan  Operator = "SCMP_CMP_GT"
-	OpMaskedEqual  Operator = "SCMP_CMP_MASKED_EQ"
+	OpNotEqual     LinuxSeccompOperator = "SCMP_CMP_NE"
+	OpLessThan     LinuxSeccompOperator = "SCMP_CMP_LT"
+	OpLessEqual    LinuxSeccompOperator = "SCMP_CMP_LE"
+	OpEqualTo      LinuxSeccompOperator = "SCMP_CMP_EQ"
+	OpGreaterEqual LinuxSeccompOperator = "SCMP_CMP_GE"
+	OpGreaterThan  LinuxSeccompOperator = "SCMP_CMP_GT"
+	OpMaskedEqual  LinuxSeccompOperator = "SCMP_CMP_MASKED_EQ"
 )
 
-// Arg used for matching specific syscall arguments in Seccomp
-type Arg struct {
-	Index    uint     `json:"index"`
-	Value    uint64   `json:"value"`
-	ValueTwo uint64   `json:"valueTwo"`
-	Op       Operator `json:"op"`
+// LinuxSeccompArg used for matching specific syscall arguments in Seccomp
+type LinuxSeccompArg struct {
+	Index    uint                 `json:"index"`
+	Value    uint64               `json:"value"`
+	ValueTwo uint64               `json:"valueTwo"`
+	Op       LinuxSeccompOperator `json:"op"`
 }
 
-// Syscall is used to match a syscall in Seccomp
-type Syscall struct {
-	Name   string `json:"name"`
-	Action Action `json:"action"`
-	Args   []Arg  `json:"args,omitempty"`
+// LinuxSyscall is used to match a syscall in Seccomp
+type LinuxSyscall struct {
+	Names   []string           `json:"names"`
+	Action  LinuxSeccompAction `json:"action"`
+	Args    []LinuxSeccompArg  `json:"args"`
+	Comment string             `json:"comment"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -3,15 +3,15 @@ package specs
 // State holds information about the runtime state of the container.
 type State struct {
 	// Version is the version of the specification that is supported.
-	Version string `json:"version"`
+	Version string `json:"ociVersion"`
 	// ID is the container ID
 	ID string `json:"id"`
-	// Status is the runtime state of the container.
+	// Status is the runtime status of the container.
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
 	Pid int `json:"pid"`
-	// BundlePath is the path to the container's bundle directory.
-	BundlePath string `json:"bundlePath"`
-	// Annotations are the annotations associated with the container.
-	Annotations map[string]string `json:"annotations"`
+	// Bundle is the path to the container's bundle directory.
+	Bundle string `json:"bundle"`
+	// Annotations are key values associated with the container.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc2"
+	VersionDev = "-rc5"
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -53,23 +53,89 @@ func New() Generator {
 				"TERM=xterm",
 			},
 			Cwd: "/",
-			Capabilities: []string{
-				"CAP_CHOWN",
-				"CAP_DAC_OVERRIDE",
-				"CAP_FSETID",
-				"CAP_FOWNER",
-				"CAP_MKNOD",
-				"CAP_NET_RAW",
-				"CAP_SETGID",
-				"CAP_SETUID",
-				"CAP_SETFCAP",
-				"CAP_SETPCAP",
-				"CAP_NET_BIND_SERVICE",
-				"CAP_SYS_CHROOT",
-				"CAP_KILL",
-				"CAP_AUDIT_WRITE",
+			Capabilities: &rspec.LinuxCapabilities{
+				Bounding: []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FSETID",
+					"CAP_FOWNER",
+					"CAP_MKNOD",
+					"CAP_NET_RAW",
+					"CAP_SETGID",
+					"CAP_SETUID",
+					"CAP_SETFCAP",
+					"CAP_SETPCAP",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SYS_CHROOT",
+					"CAP_KILL",
+					"CAP_AUDIT_WRITE",
+				},
+				Permitted: []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FSETID",
+					"CAP_FOWNER",
+					"CAP_MKNOD",
+					"CAP_NET_RAW",
+					"CAP_SETGID",
+					"CAP_SETUID",
+					"CAP_SETFCAP",
+					"CAP_SETPCAP",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SYS_CHROOT",
+					"CAP_KILL",
+					"CAP_AUDIT_WRITE",
+				},
+				Inheritable: []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FSETID",
+					"CAP_FOWNER",
+					"CAP_MKNOD",
+					"CAP_NET_RAW",
+					"CAP_SETGID",
+					"CAP_SETUID",
+					"CAP_SETFCAP",
+					"CAP_SETPCAP",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SYS_CHROOT",
+					"CAP_KILL",
+					"CAP_AUDIT_WRITE",
+				},
+				Effective: []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FSETID",
+					"CAP_FOWNER",
+					"CAP_MKNOD",
+					"CAP_NET_RAW",
+					"CAP_SETGID",
+					"CAP_SETUID",
+					"CAP_SETFCAP",
+					"CAP_SETPCAP",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SYS_CHROOT",
+					"CAP_KILL",
+					"CAP_AUDIT_WRITE",
+				},
+				Ambient: []string{
+					"CAP_CHOWN",
+					"CAP_DAC_OVERRIDE",
+					"CAP_FSETID",
+					"CAP_FOWNER",
+					"CAP_MKNOD",
+					"CAP_NET_RAW",
+					"CAP_SETGID",
+					"CAP_SETUID",
+					"CAP_SETFCAP",
+					"CAP_SETPCAP",
+					"CAP_NET_BIND_SERVICE",
+					"CAP_SYS_CHROOT",
+					"CAP_KILL",
+					"CAP_AUDIT_WRITE",
+				},
 			},
-			Rlimits: []rspec.Rlimit{
+			Rlimits: []rspec.LinuxRlimit{
 				{
 					Type: "RLIMIT_NOFILE",
 					Hard: uint64(1024),
@@ -117,15 +183,15 @@ func New() Generator {
 			},
 		},
 		Linux: &rspec.Linux{
-			Resources: &rspec.Resources{
-				Devices: []rspec.DeviceCgroup{
+			Resources: &rspec.LinuxResources{
+				Devices: []rspec.LinuxDeviceCgroup{
 					{
 						Allow:  false,
-						Access: strPtr("rwm"),
+						Access: "rwm",
 					},
 				},
 			},
-			Namespaces: []rspec.Namespace{
+			Namespaces: []rspec.LinuxNamespace{
 				{
 					Type: "pid",
 				},
@@ -142,7 +208,7 @@ func New() Generator {
 					Type: "mount",
 				},
 			},
-			Devices: []rspec.Device{},
+			Devices: []rspec.LinuxDevice{},
 		},
 	}
 	spec.Linux.Seccomp = seccomp.DefaultProfile(&spec)
@@ -195,6 +261,16 @@ func (g *Generator) Spec() *rspec.Spec {
 // Save writes the spec into w.
 func (g *Generator) Save(w io.Writer, exportOpts ExportOptions) (err error) {
 	var data []byte
+
+	if g.spec.Linux != nil {
+		buf, err := json.Marshal(g.spec.Linux)
+		if err != nil {
+			return err
+		}
+		if string(buf) == "{}" {
+			g.spec.Linux = nil
+		}
+	}
 
 	if exportOpts.Seccomp {
 		data, err = json.MarshalIndent(g.spec.Linux.Seccomp, "", "\t")
@@ -357,7 +433,7 @@ func (g *Generator) AddProcessRlimits(rType string, rHard uint64, rSoft uint64) 
 		}
 	}
 
-	newRlimit := rspec.Rlimit{
+	newRlimit := rspec.LinuxRlimit{
 		Type: rType,
 		Hard: rHard,
 		Soft: rSoft,
@@ -384,7 +460,7 @@ func (g *Generator) ClearProcessRlimits() {
 	if g.spec == nil {
 		return
 	}
-	g.spec.Process.Rlimits = []rspec.Rlimit{}
+	g.spec.Process.Rlimits = []rspec.LinuxRlimit{}
 }
 
 // ClearProcessAdditionalGids clear g.spec.Process.AdditionalGids.
@@ -415,7 +491,7 @@ func (g *Generator) SetProcessSelinuxLabel(label string) {
 // SetLinuxCgroupsPath sets g.spec.Linux.CgroupsPath.
 func (g *Generator) SetLinuxCgroupsPath(path string) {
 	g.initSpecLinux()
-	g.spec.Linux.CgroupsPath = strPtr(path)
+	g.spec.Linux.CgroupsPath = path
 }
 
 // SetLinuxMountLabel sets g.spec.Linux.MountLabel.
@@ -443,7 +519,7 @@ func (g *Generator) SetLinuxResourcesCPUShares(shares uint64) {
 }
 
 // SetLinuxResourcesCPUQuota sets g.spec.Linux.Resources.CPU.Quota.
-func (g *Generator) SetLinuxResourcesCPUQuota(quota uint64) {
+func (g *Generator) SetLinuxResourcesCPUQuota(quota int64) {
 	g.initSpecLinuxResourcesCPU()
 	g.spec.Linux.Resources.CPU.Quota = &quota
 }
@@ -455,7 +531,7 @@ func (g *Generator) SetLinuxResourcesCPUPeriod(period uint64) {
 }
 
 // SetLinuxResourcesCPURealtimeRuntime sets g.spec.Linux.Resources.CPU.RealtimeRuntime.
-func (g *Generator) SetLinuxResourcesCPURealtimeRuntime(time uint64) {
+func (g *Generator) SetLinuxResourcesCPURealtimeRuntime(time int64) {
 	g.initSpecLinuxResourcesCPU()
 	g.spec.Linux.Resources.CPU.RealtimeRuntime = &time
 }
@@ -469,13 +545,13 @@ func (g *Generator) SetLinuxResourcesCPURealtimePeriod(period uint64) {
 // SetLinuxResourcesCPUCpus sets g.spec.Linux.Resources.CPU.Cpus.
 func (g *Generator) SetLinuxResourcesCPUCpus(cpus string) {
 	g.initSpecLinuxResourcesCPU()
-	g.spec.Linux.Resources.CPU.Cpus = &cpus
+	g.spec.Linux.Resources.CPU.Cpus = cpus
 }
 
 // SetLinuxResourcesCPUMems sets g.spec.Linux.Resources.CPU.Mems.
 func (g *Generator) SetLinuxResourcesCPUMems(mems string) {
 	g.initSpecLinuxResourcesCPU()
-	g.spec.Linux.Resources.CPU.Mems = &mems
+	g.spec.Linux.Resources.CPU.Mems = mems
 }
 
 // SetLinuxResourcesMemoryLimit sets g.spec.Linux.Resources.Memory.Limit.
@@ -529,7 +605,7 @@ func (g *Generator) AddLinuxResourcesNetworkPriorities(name string, prio uint32)
 			return
 		}
 	}
-	interfacePrio := new(rspec.InterfacePriority)
+	interfacePrio := new(rspec.LinuxInterfacePriority)
 	interfacePrio.Name = name
 	interfacePrio.Priority = prio
 	g.spec.Linux.Resources.Network.Priorities = append(g.spec.Linux.Resources.Network.Priorities, *interfacePrio)
@@ -549,7 +625,7 @@ func (g *Generator) DropLinuxResourcesNetworkPriorities(name string) {
 // SetLinuxResourcesPidsLimit sets g.spec.Linux.Resources.Pids.Limit.
 func (g *Generator) SetLinuxResourcesPidsLimit(limit int64) {
 	g.initSpecLinuxResourcesPids()
-	g.spec.Linux.Resources.Pids.Limit = &limit
+	g.spec.Linux.Resources.Pids.Limit = limit
 }
 
 // ClearLinuxSysctl clears g.spec.Linux.Sysctl.
@@ -579,12 +655,12 @@ func (g *Generator) ClearLinuxUIDMappings() {
 	if g.spec == nil || g.spec.Linux == nil {
 		return
 	}
-	g.spec.Linux.UIDMappings = []rspec.IDMapping{}
+	g.spec.Linux.UIDMappings = []rspec.LinuxIDMapping{}
 }
 
 // AddLinuxUIDMapping adds uidMap into g.spec.Linux.UIDMappings.
 func (g *Generator) AddLinuxUIDMapping(hid, cid, size uint32) {
-	idMapping := rspec.IDMapping{
+	idMapping := rspec.LinuxIDMapping{
 		HostID:      hid,
 		ContainerID: cid,
 		Size:        size,
@@ -599,12 +675,12 @@ func (g *Generator) ClearLinuxGIDMappings() {
 	if g.spec == nil || g.spec.Linux == nil {
 		return
 	}
-	g.spec.Linux.GIDMappings = []rspec.IDMapping{}
+	g.spec.Linux.GIDMappings = []rspec.LinuxIDMapping{}
 }
 
 // AddLinuxGIDMapping adds gidMap into g.spec.Linux.GIDMappings.
 func (g *Generator) AddLinuxGIDMapping(hid, cid, size uint32) {
-	idMapping := rspec.IDMapping{
+	idMapping := rspec.LinuxIDMapping{
 		HostID:      hid,
 		ContainerID: cid,
 		Size:        size,
@@ -695,7 +771,6 @@ func (g *Generator) AddCgroupsMount(mountCgroupOption string) error {
 	switch mountCgroupOption {
 	case "ro":
 	case "rw":
-		break
 	case "no":
 		return nil
 	default:
@@ -743,25 +818,8 @@ func (g *Generator) AddBindMount(source, dest string, options []string) {
 	g.spec.Mounts = append(g.spec.Mounts, mnt)
 }
 
-// SetupPrivileged sets up the privilege-related fields inside g.spec.
-func (g *Generator) SetupPrivileged(privileged bool) {
-	if privileged {
-		// Add all capabilities in privileged mode.
-		var finalCapList []string
-		for _, cap := range capability.List() {
-			if g.HostSpecific && cap > lastCap() {
-				continue
-			}
-			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
-		}
-		g.initSpecLinux()
-		g.spec.Process.Capabilities = finalCapList
-		g.spec.Process.SelinuxLabel = ""
-		g.spec.Process.ApparmorProfile = ""
-		g.spec.Linux.Seccomp = nil
-	}
-}
-
+// lastCap return last cap of system, and is required to hack around RHEL6.
+// This is an exact copy of "validate/validate.go".lastCap.
 func lastCap() capability.Cap {
 	last := capability.CAP_LAST_CAP
 	// hack for RHEL6 which has no /proc/sys/kernel/cap_last_cap
@@ -772,24 +830,26 @@ func lastCap() capability.Cap {
 	return last
 }
 
-func checkCap(c string, hostSpecific bool) error {
-	isValid := false
-	cp := strings.ToUpper(c)
-
-	for _, cap := range capability.List() {
-		if cp == strings.ToUpper(cap.String()) {
-			if hostSpecific && cap > lastCap() {
-				return fmt.Errorf("CAP_%s is not supported on the current host", cp)
+// SetupPrivileged sets up the privilege-related fields inside g.spec.
+func (g *Generator) SetupPrivileged(privileged bool) {
+	if privileged { // Add all capabilities in privileged mode.
+		var finalCapList []string
+		for _, cap := range capability.List() {
+			if g.HostSpecific && cap > lastCap() {
+				continue
 			}
-			isValid = true
-			break
+			finalCapList = append(finalCapList, fmt.Sprintf("CAP_%s", strings.ToUpper(cap.String())))
 		}
+		g.initSpecLinux()
+		g.spec.Process.Capabilities.Bounding = finalCapList
+		g.spec.Process.Capabilities.Effective = finalCapList
+		g.spec.Process.Capabilities.Inheritable = finalCapList
+		g.spec.Process.Capabilities.Permitted = finalCapList
+		g.spec.Process.Capabilities.Ambient = finalCapList
+		g.spec.Process.SelinuxLabel = ""
+		g.spec.Process.ApparmorProfile = ""
+		g.spec.Linux.Seccomp = nil
 	}
-
-	if !isValid {
-		return fmt.Errorf("Invalid value passed for adding capability")
-	}
-	return nil
 }
 
 // ClearProcessCapabilities clear g.spec.Process.Capabilities.
@@ -797,40 +857,92 @@ func (g *Generator) ClearProcessCapabilities() {
 	if g.spec == nil {
 		return
 	}
-	g.spec.Process.Capabilities = []string{}
+	g.spec.Process.Capabilities.Bounding = []string{}
+	g.spec.Process.Capabilities.Effective = []string{}
+	g.spec.Process.Capabilities.Inheritable = []string{}
+	g.spec.Process.Capabilities.Permitted = []string{}
+	g.spec.Process.Capabilities.Ambient = []string{}
 }
 
 // AddProcessCapability adds a process capability into g.spec.Process.Capabilities.
 func (g *Generator) AddProcessCapability(c string) error {
-	if err := checkCap(c, g.HostSpecific); err != nil {
-		return err
-	}
-
-	cp := fmt.Sprintf("CAP_%s", strings.ToUpper(c))
-
 	g.initSpec()
-	for _, cap := range g.spec.Process.Capabilities {
+	cp := strings.ToUpper(c)
+
+	for _, cap := range g.spec.Process.Capabilities.Bounding {
 		if strings.ToUpper(cap) == cp {
 			return nil
 		}
 	}
+	g.spec.Process.Capabilities.Bounding = append(g.spec.Process.Capabilities.Bounding, cp)
 
-	g.spec.Process.Capabilities = append(g.spec.Process.Capabilities, cp)
+	for _, cap := range g.spec.Process.Capabilities.Effective {
+		if strings.ToUpper(cap) == cp {
+			return nil
+		}
+	}
+	g.spec.Process.Capabilities.Effective = append(g.spec.Process.Capabilities.Effective, cp)
+
+	for _, cap := range g.spec.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			return nil
+		}
+	}
+	g.spec.Process.Capabilities.Inheritable = append(g.spec.Process.Capabilities.Inheritable, cp)
+
+	for _, cap := range g.spec.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			return nil
+		}
+	}
+	g.spec.Process.Capabilities.Permitted = append(g.spec.Process.Capabilities.Permitted, cp)
+
+	for _, cap := range g.spec.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			return nil
+		}
+	}
+	g.spec.Process.Capabilities.Ambient = append(g.spec.Process.Capabilities.Ambient, cp)
+
 	return nil
 }
 
 // DropProcessCapability drops a process capability from g.spec.Process.Capabilities.
 func (g *Generator) DropProcessCapability(c string) error {
-	if err := checkCap(c, g.HostSpecific); err != nil {
-		return err
+	g.initSpec()
+	cp := strings.ToUpper(c)
+
+	for i, cap := range g.spec.Process.Capabilities.Bounding {
+		if strings.ToUpper(cap) == cp {
+			g.spec.Process.Capabilities.Bounding = append(g.spec.Process.Capabilities.Bounding[:i], g.spec.Process.Capabilities.Bounding[i+1:]...)
+			return nil
+		}
 	}
 
-	cp := fmt.Sprintf("CAP_%s", strings.ToUpper(c))
-
-	g.initSpec()
-	for i, cap := range g.spec.Process.Capabilities {
+	for i, cap := range g.spec.Process.Capabilities.Effective {
 		if strings.ToUpper(cap) == cp {
-			g.spec.Process.Capabilities = append(g.spec.Process.Capabilities[:i], g.spec.Process.Capabilities[i+1:]...)
+			g.spec.Process.Capabilities.Effective = append(g.spec.Process.Capabilities.Effective[:i], g.spec.Process.Capabilities.Effective[i+1:]...)
+			return nil
+		}
+	}
+
+	for i, cap := range g.spec.Process.Capabilities.Inheritable {
+		if strings.ToUpper(cap) == cp {
+			g.spec.Process.Capabilities.Inheritable = append(g.spec.Process.Capabilities.Inheritable[:i], g.spec.Process.Capabilities.Inheritable[i+1:]...)
+			return nil
+		}
+	}
+
+	for i, cap := range g.spec.Process.Capabilities.Permitted {
+		if strings.ToUpper(cap) == cp {
+			g.spec.Process.Capabilities.Permitted = append(g.spec.Process.Capabilities.Permitted[:i], g.spec.Process.Capabilities.Permitted[i+1:]...)
+			return nil
+		}
+	}
+
+	for i, cap := range g.spec.Process.Capabilities.Ambient {
+		if strings.ToUpper(cap) == cp {
+			g.spec.Process.Capabilities.Ambient = append(g.spec.Process.Capabilities.Ambient[:i], g.spec.Process.Capabilities.Ambient[i+1:]...)
 			return nil
 		}
 	}
@@ -838,24 +950,24 @@ func (g *Generator) DropProcessCapability(c string) error {
 	return nil
 }
 
-func mapStrToNamespace(ns string, path string) (rspec.Namespace, error) {
+func mapStrToNamespace(ns string, path string) (rspec.LinuxNamespace, error) {
 	switch ns {
 	case "network":
-		return rspec.Namespace{Type: rspec.NetworkNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.NetworkNamespace, Path: path}, nil
 	case "pid":
-		return rspec.Namespace{Type: rspec.PIDNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.PIDNamespace, Path: path}, nil
 	case "mount":
-		return rspec.Namespace{Type: rspec.MountNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.MountNamespace, Path: path}, nil
 	case "ipc":
-		return rspec.Namespace{Type: rspec.IPCNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.IPCNamespace, Path: path}, nil
 	case "uts":
-		return rspec.Namespace{Type: rspec.UTSNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.UTSNamespace, Path: path}, nil
 	case "user":
-		return rspec.Namespace{Type: rspec.UserNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.UserNamespace, Path: path}, nil
 	case "cgroup":
-		return rspec.Namespace{Type: rspec.CgroupNamespace, Path: path}, nil
+		return rspec.LinuxNamespace{Type: rspec.CgroupNamespace, Path: path}, nil
 	default:
-		return rspec.Namespace{}, fmt.Errorf("Should not reach here!")
+		return rspec.LinuxNamespace{}, fmt.Errorf("Should not reach here!")
 	}
 }
 
@@ -864,7 +976,7 @@ func (g *Generator) ClearLinuxNamespaces() {
 	if g.spec == nil || g.spec.Linux == nil {
 		return
 	}
-	g.spec.Linux.Namespaces = []rspec.Namespace{}
+	g.spec.Linux.Namespaces = []rspec.LinuxNamespace{}
 }
 
 // AddOrReplaceLinuxNamespace adds or replaces a namespace inside
@@ -903,6 +1015,22 @@ func (g *Generator) RemoveLinuxNamespace(ns string) error {
 		}
 	}
 	return nil
+}
+
+// AddDevice - add a device into g.spec.Linux.Devices
+func (g *Generator) AddDevice(path, devType string, major, minor int64, fileMode *os.FileMode, uid, gid *uint32) {
+	g.initSpecLinux()
+
+	device := rspec.LinuxDevice{
+		Path:     path,
+		Type:     devType,
+		Major:    major,
+		Minor:    minor,
+		FileMode: fileMode,
+		UID:      uid,
+		GID:      gid,
+	}
+	g.spec.Linux.Devices = append(g.spec.Linux.Devices, device)
 }
 
 // strPtr returns the pointer pointing to the string s.

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_action.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_action.go
@@ -20,7 +20,7 @@ type SyscallOpts struct {
 
 // ParseSyscallFlag takes a SyscallOpts struct and the seccomp configuration
 // and sets the new syscall rule accordingly
-func ParseSyscallFlag(args SyscallOpts, config *rspec.Seccomp) error {
+func ParseSyscallFlag(args SyscallOpts, config *rspec.LinuxSeccomp) error {
 	var arguments []string
 	if args.Index != "" && args.Value != "" && args.ValueTwo != "" && args.Operator != "" {
 		arguments = []string{args.Action, args.Syscall, args.Index, args.Value,
@@ -34,7 +34,7 @@ func ParseSyscallFlag(args SyscallOpts, config *rspec.Seccomp) error {
 		return fmt.Errorf("default action already set as %s", action)
 	}
 
-	var newSyscall rspec.Syscall
+	var newSyscall rspec.LinuxSyscall
 	numOfArgs := len(arguments)
 	if numOfArgs == 6 || numOfArgs == 2 {
 		argStruct, err := parseArguments(arguments[1:])
@@ -67,7 +67,7 @@ func ParseSyscallFlag(args SyscallOpts, config *rspec.Seccomp) error {
 	return nil
 }
 
-var actions = map[string]rspec.Action{
+var actions = map[string]rspec.LinuxSeccompAction{
 	"allow": rspec.ActAllow,
 	"errno": rspec.ActErrno,
 	"kill":  rspec.ActKill,
@@ -76,7 +76,7 @@ var actions = map[string]rspec.Action{
 }
 
 // Take passed action, return the SCMP_ACT_<ACTION> version of it
-func parseAction(action string) (rspec.Action, error) {
+func parseAction(action string) (rspec.LinuxSeccompAction, error) {
 	a, ok := actions[action]
 	if !ok {
 		return "", fmt.Errorf("unrecognized action: %s", action)
@@ -86,7 +86,7 @@ func parseAction(action string) (rspec.Action, error) {
 
 // ParseDefaultAction sets the default action of the seccomp configuration
 // and then removes any rules that were already specified with this action
-func ParseDefaultAction(action string, config *rspec.Seccomp) error {
+func ParseDefaultAction(action string, config *rspec.LinuxSeccomp) error {
 	if action == "" {
 		return nil
 	}
@@ -104,7 +104,7 @@ func ParseDefaultAction(action string, config *rspec.Seccomp) error {
 }
 
 // ParseDefaultActionForce simply sets the default action of the seccomp configuration
-func ParseDefaultActionForce(action string, config *rspec.Seccomp) error {
+func ParseDefaultActionForce(action string, config *rspec.LinuxSeccomp) error {
 	if action == "" {
 		return nil
 	}
@@ -117,9 +117,9 @@ func ParseDefaultActionForce(action string, config *rspec.Seccomp) error {
 	return nil
 }
 
-func newSyscallStruct(name string, action rspec.Action, args []rspec.Arg) rspec.Syscall {
-	syscallStruct := rspec.Syscall{
-		Name:   name,
+func newSyscallStruct(name string, action rspec.LinuxSeccompAction, args []rspec.LinuxSeccompArg) rspec.LinuxSyscall {
+	syscallStruct := rspec.LinuxSyscall{
+		Names:  []string{name},
 		Action: action,
 		Args:   args,
 	}

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_architecture.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_architecture.go
@@ -8,7 +8,7 @@ import (
 
 // ParseArchitectureFlag takes the raw string passed with the --arch flag, parses it
 // and updates the Seccomp config accordingly
-func ParseArchitectureFlag(architectureArg string, config *rspec.Seccomp) error {
+func ParseArchitectureFlag(architectureArg string, config *rspec.LinuxSeccomp) error {
 	correctedArch, err := parseArch(architectureArg)
 	if err != nil {
 		return err

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_arguments.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/parse_arguments.go
@@ -9,8 +9,8 @@ import (
 
 // parseArguments takes a list of arguments (delimArgs). It parses and fills out
 // the argument information and returns a slice of arg structs
-func parseArguments(delimArgs []string) ([]rspec.Arg, error) {
-	nilArgSlice := []rspec.Arg{}
+func parseArguments(delimArgs []string) ([]rspec.LinuxSeccompArg, error) {
+	nilArgSlice := []rspec.LinuxSeccompArg{}
 	numberOfArgs := len(delimArgs)
 
 	// No parameters passed with syscall
@@ -40,14 +40,14 @@ func parseArguments(delimArgs []string) ([]rspec.Arg, error) {
 			return nilArgSlice, err
 		}
 
-		argStruct := rspec.Arg{
+		argStruct := rspec.LinuxSeccompArg{
 			Index:    uint(syscallIndex),
 			Value:    syscallValue,
 			ValueTwo: syscallValueTwo,
 			Op:       syscallOp,
 		}
 
-		argSlice := []rspec.Arg{}
+		argSlice := []rspec.LinuxSeccompArg{}
 		argSlice = append(argSlice, argStruct)
 		return argSlice, nil
 	}
@@ -55,8 +55,8 @@ func parseArguments(delimArgs []string) ([]rspec.Arg, error) {
 	return nilArgSlice, fmt.Errorf("incorrect number of arguments passed with syscall: %d", numberOfArgs)
 }
 
-func parseOperator(operator string) (rspec.Operator, error) {
-	operators := map[string]rspec.Operator{
+func parseOperator(operator string) (rspec.LinuxSeccompOperator, error) {
+	operators := map[string]rspec.LinuxSeccompOperator{
 		"NE": rspec.OpNotEqual,
 		"LT": rspec.OpLessThan,
 		"LE": rspec.OpLessEqual,

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/seccomp_default.go
@@ -32,851 +32,333 @@ func arches() []rspec.Arch {
 }
 
 // DefaultProfile defines the whitelist for the default seccomp profile.
-func DefaultProfile(rs *specs.Spec) *rspec.Seccomp {
+func DefaultProfile(rs *specs.Spec) *rspec.LinuxSeccomp {
 
-	syscalls := []rspec.Syscall{
-		{
-			Name:   "accept",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "accept4",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "access",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "alarm",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "bind",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "brk",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "capget",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "capset",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "chdir",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "chmod",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "chown",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "chown32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-
-		{
-			Name:   "clock_getres",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "clock_gettime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "clock_nanosleep",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "close",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "connect",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "copy_file_range",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "creat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "dup",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "dup2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "dup3",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_create",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_create1",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_ctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_ctl_old",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_pwait",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_wait",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "epoll_wait_old",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "eventfd",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "eventfd2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "execve",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "execveat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "exit",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "exit_group",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "faccessat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fadvise64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fadvise64_64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fallocate",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fanotify_mark",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchdir",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchmod",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchmodat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchown",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchown32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fchownat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fcntl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fcntl64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fdatasync",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fgetxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "flistxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "flock",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fork",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fremovexattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fsetxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fstat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fstat64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fstatat64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fstatfs",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fstatfs64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "fsync",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ftruncate",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ftruncate64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "futex",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "futimesat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getcpu",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getcwd",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getdents",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getdents64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getegid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getegid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "geteuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "geteuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getgid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getgroups",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getgroups32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getitimer",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getpeername",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getpgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getpgrp",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getpid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getppid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getpriority",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getrandom",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getresgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getresgid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getresuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getresuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getrlimit",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "get_robust_list",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getrusage",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getsid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getsockname",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getsockopt",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "get_thread_area",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "gettid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "gettimeofday",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "getxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "inotify_add_watch",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "inotify_init",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "inotify_init1",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "inotify_rm_watch",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "io_cancel",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ioctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "io_destroy",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "io_getevents",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ioprio_get",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ioprio_set",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "io_setup",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "io_submit",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ipc",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "kill",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lchown",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lchown32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lgetxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "link",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "linkat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "listen",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "listxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "llistxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "_llseek",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lremovexattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lseek",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lsetxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lstat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "lstat64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "madvise",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "memfd_create",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mincore",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mkdir",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mkdirat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mknod",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mknodat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mlock",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mlock2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mlockall",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mmap",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mmap2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mprotect",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_getsetattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_notify",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_open",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_timedreceive",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_timedsend",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mq_unlink",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "mremap",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "msgctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "msgget",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "msgrcv",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "msgsnd",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "msync",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "munlock",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "munlockall",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "munmap",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "nanosleep",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "newfstatat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "_newselect",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "open",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "openat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pause",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "personality",
-			Action: rspec.ActAllow,
-			Args: []rspec.Arg{
+	syscalls := []rspec.LinuxSyscall{
+		{
+			Names: []string{
+				"accept",
+				"accept4",
+				"access",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"get_robust_list",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"get_thread_area",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"ioctl",
+				"io_destroy",
+				"io_getevents",
+				"ioprio_get",
+				"ioprio_set",
+				"io_setup",
+				"io_submit",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"_llseek",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"nanosleep",
+				"newfstatat",
+				"_newselect",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"set_robust_list",
+				"setsid",
+				"setsockopt",
+				"set_thread_area",
+				"set_tid_address",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev",
+			},
+			Action: rspec.ActAllow,
+			Args:   []rspec.LinuxSeccompArg{},
+		},
+		{
+			Names:  []string{"personality"},
+			Action: rspec.ActAllow,
+			Args: []rspec.LinuxSeccompArg{
 				{
 					Index: 0,
 					Value: 0x0,
 					Op:    rspec.OpEqualTo,
 				},
-			},
-		},
-		{
-			Name:   "personality",
-			Action: rspec.ActAllow,
-			Args: []rspec.Arg{
 				{
 					Index: 0,
 					Value: 0x0008,
 					Op:    rspec.OpEqualTo,
 				},
-			},
-		},
-		{
-			Name:   "personality",
-			Action: rspec.ActAllow,
-			Args: []rspec.Arg{
 				{
 					Index: 0,
 					Value: 0xffffffff,
@@ -884,914 +366,152 @@ func DefaultProfile(rs *specs.Spec) *rspec.Seccomp {
 				},
 			},
 		},
-		{
-			Name:   "pipe",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pipe2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "poll",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ppoll",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "prctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pread64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "preadv",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "prlimit64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pselect6",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pwrite64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "pwritev",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "read",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "readahead",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "readlink",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "readlinkat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "readv",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "recv",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "recvfrom",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "recvmmsg",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "recvmsg",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "remap_file_pages",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "removexattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rename",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "renameat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "renameat2",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "restart_syscall",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rmdir",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigaction",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigpending",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigprocmask",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigqueueinfo",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigreturn",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigsuspend",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_sigtimedwait",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "rt_tgsigqueueinfo",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_getaffinity",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_getattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_getparam",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_get_priority_max",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_get_priority_min",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_getscheduler",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_rr_get_interval",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_setaffinity",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_setattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_setparam",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_setscheduler",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sched_yield",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "seccomp",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "select",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "semctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "semget",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "semop",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "semtimedop",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "send",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sendfile",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sendfile64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sendmmsg",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sendmsg",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sendto",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setfsgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setfsgid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setfsuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setfsuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setgid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setgroups",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setgroups32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setitimer",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setpgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setpriority",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setregid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setregid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setresgid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setresgid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setresuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setresuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setreuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setreuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setrlimit",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "set_robust_list",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setsid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setsockopt",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "set_thread_area",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "set_tid_address",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setuid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setuid32",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "setxattr",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "shmat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "shmctl",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "shmdt",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "shmget",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "shutdown",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sigaltstack",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "signalfd",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "signalfd4",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sigreturn",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "socket",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "socketcall",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "socketpair",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "splice",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "stat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "stat64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "statfs",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "statfs64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "symlink",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "symlinkat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sync",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sync_file_range",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "syncfs",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "sysinfo",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "syslog",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "tee",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "tgkill",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "time",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timer_create",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timer_delete",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timerfd_create",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timerfd_gettime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timerfd_settime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timer_getoverrun",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timer_gettime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "timer_settime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "times",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "tkill",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "truncate",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "truncate64",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "ugetrlimit",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "umask",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "uname",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "unlink",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "unlinkat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "utime",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "utimensat",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "utimes",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "vfork",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "vmsplice",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "wait4",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "waitid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "waitpid",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "write",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
-		{
-			Name:   "writev",
-			Action: rspec.ActAllow,
-			Args:   []rspec.Arg{},
-		},
 	}
 	var sysCloneFlagsIndex uint
 
 	capSysAdmin := false
 	var cap string
+	var caps []string
 
-	for _, cap = range rs.Process.Capabilities {
+	for _, cap = range rs.Process.Capabilities.Bounding {
+		caps = append(caps, cap)
+	}
+	for _, cap = range rs.Process.Capabilities.Effective {
+		caps = append(caps, cap)
+	}
+	for _, cap = range rs.Process.Capabilities.Inheritable {
+		caps = append(caps, cap)
+	}
+	for _, cap = range rs.Process.Capabilities.Permitted {
+		caps = append(caps, cap)
+	}
+	for _, cap = range rs.Process.Capabilities.Ambient {
+		caps = append(caps, cap)
+	}
+
+	for _, cap = range caps {
 		switch cap {
 		case "CAP_DAC_READ_SEARCH":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "open_by_handle_at",
+					Names:  []string{"open_by_handle_at"},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_ADMIN":
 			capSysAdmin = true
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "bpf",
+					Names: []string{
+						"bpf",
+						"clone",
+						"fanotify_init",
+						"lookup_dcookie",
+						"mount",
+						"name_to_handle_at",
+						"perf_event_open",
+						"setdomainname",
+						"sethostname",
+						"setns",
+						"umount",
+						"umount2",
+						"unshare",
+					},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "clone",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "fanotify_init",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "lookup_dcookie",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "mount",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "name_to_handle_at",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "perf_event_open",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "setdomainname",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "sethostname",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "setns",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "umount",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "umount2",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "unshare",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_BOOT":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "reboot",
+					Names:  []string{"reboot"},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_CHROOT":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "chroot",
+					Names:  []string{"chroot"},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_MODULE":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "delete_module",
+					Names: []string{
+						"delete_module",
+						"init_module",
+						"finit_module",
+						"query_module",
+					},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "init_module",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "finit_module",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "query_module",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_PACCT":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "acct",
+					Names:  []string{"acct"},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_PTRACE":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "kcmp",
+					Names: []string{
+						"kcmp",
+						"process_vm_readv",
+						"process_vm_writev",
+						"ptrace",
+					},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "process_vm_readv",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "process_vm_writev",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "ptrace",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_RAWIO":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "iopl",
+					Names: []string{
+						"iopl",
+						"ioperm",
+					},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "ioperm",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_TIME":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "settimeofday",
+					Names: []string{
+						"settimeofday",
+						"stime",
+						"adjtimex",
+					},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "stime",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
-				},
-				{
-					Name:   "adjtimex",
-					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		case "CAP_SYS_TTY_CONFIG":
-			syscalls = append(syscalls, []rspec.Syscall{
+			syscalls = append(syscalls, []rspec.LinuxSyscall{
 				{
-					Name:   "vhangup",
+					Names:  []string{"vhangup"},
 					Action: rspec.ActAllow,
-					Args:   []rspec.Arg{},
+					Args:   []rspec.LinuxSeccompArg{},
 				},
 			}...)
 		}
 	}
 
 	if !capSysAdmin {
-		syscalls = append(syscalls, []rspec.Syscall{
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
 			{
-				Name:   "clone",
+				Names:  []string{"clone"},
 				Action: rspec.ActAllow,
-				Args: []rspec.Arg{
+				Args: []rspec.LinuxSeccompArg{
 					{
 						Index:    sysCloneFlagsIndex,
 						Value:    syscall.CLONE_NEWNS | syscall.CLONE_NEWUTS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWUSER | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET,
@@ -1807,62 +527,50 @@ func DefaultProfile(rs *specs.Spec) *rspec.Seccomp {
 	arch := runtime.GOARCH
 	switch arch {
 	case "arm", "arm64":
-		syscalls = append(syscalls, []rspec.Syscall{
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
 			{
-				Name:   "breakpoint",
+				Names: []string{
+					"breakpoint",
+					"cacheflush",
+					"set_tls",
+				},
 				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
-			},
-			{
-				Name:   "cacheflush",
-				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
-			},
-			{
-				Name:   "set_tls",
-				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
+				Args:   []rspec.LinuxSeccompArg{},
 			},
 		}...)
 	case "amd64", "x32":
-		syscalls = append(syscalls, []rspec.Syscall{
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
 			{
-				Name:   "arch_prctl",
+				Names:  []string{"arch_prctl"},
 				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
+				Args:   []rspec.LinuxSeccompArg{},
 			},
 		}...)
 		fallthrough
 	case "x86":
-		syscalls = append(syscalls, []rspec.Syscall{
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
 			{
-				Name:   "modify_ldt",
+				Names:  []string{"modify_ldt"},
 				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
+				Args:   []rspec.LinuxSeccompArg{},
 			},
 		}...)
 	case "s390", "s390x":
-		syscalls = append(syscalls, []rspec.Syscall{
+		syscalls = append(syscalls, []rspec.LinuxSyscall{
 			{
-				Name:   "s390_pci_mmio_read",
+				Names: []string{
+					"s390_pci_mmio_read",
+					"s390_pci_mmio_write",
+					"s390_runtime_instr",
+				},
 				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
-			},
-			{
-				Name:   "s390_pci_mmio_write",
-				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
-			},
-			{
-				Name:   "s390_runtime_instr",
-				Action: rspec.ActAllow,
-				Args:   []rspec.Arg{},
+				Args:   []rspec.LinuxSeccompArg{},
 			},
 		}...)
 		/* Flags parameter of the clone syscall is the 2nd on s390 */
 	}
 
-	return &rspec.Seccomp{
+	return &rspec.LinuxSeccomp{
 		DefaultAction: rspec.ActErrno,
 		Architectures: arches(),
 		Syscalls:      syscalls,

--- a/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/seccomp/syscall_compare.go
@@ -11,12 +11,12 @@ import (
 
 // Determine if a new syscall rule should be appended, overwrite an existing rule
 // or if no action should be taken at all
-func decideCourseOfAction(newSyscall *rspec.Syscall, syscalls []rspec.Syscall) (string, error) {
+func decideCourseOfAction(newSyscall *rspec.LinuxSyscall, syscalls []rspec.LinuxSyscall) (string, error) {
 	ruleForSyscallAlreadyExists := false
 
 	var sliceOfDeterminedActions []string
 	for i, syscall := range syscalls {
-		if syscall.Name == newSyscall.Name {
+		if sameName(&syscall, newSyscall) {
 			ruleForSyscallAlreadyExists = true
 
 			if identical(newSyscall, &syscall) {
@@ -83,16 +83,16 @@ func decideCourseOfAction(newSyscall *rspec.Syscall, syscalls []rspec.Syscall) (
 	return "", fmt.Errorf("Trouble determining action: %s", sliceOfDeterminedActions)
 }
 
-func hasArguments(config *rspec.Syscall) bool {
-	nilSyscall := new(rspec.Syscall)
+func hasArguments(config *rspec.LinuxSyscall) bool {
+	nilSyscall := new(rspec.LinuxSyscall)
 	return !sameArgs(nilSyscall, config)
 }
 
-func identical(config1, config2 *rspec.Syscall) bool {
+func identical(config1, config2 *rspec.LinuxSyscall) bool {
 	return reflect.DeepEqual(config1, config2)
 }
 
-func identicalExceptAction(config1, config2 *rspec.Syscall) bool {
+func identicalExceptAction(config1, config2 *rspec.LinuxSyscall) bool {
 	samename := sameName(config1, config2)
 	sameAction := sameAction(config1, config2)
 	sameArgs := sameArgs(config1, config2)
@@ -100,7 +100,7 @@ func identicalExceptAction(config1, config2 *rspec.Syscall) bool {
 	return samename && !sameAction && sameArgs
 }
 
-func identicalExceptArgs(config1, config2 *rspec.Syscall) bool {
+func identicalExceptArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	samename := sameName(config1, config2)
 	sameAction := sameAction(config1, config2)
 	sameArgs := sameArgs(config1, config2)
@@ -108,33 +108,33 @@ func identicalExceptArgs(config1, config2 *rspec.Syscall) bool {
 	return samename && sameAction && !sameArgs
 }
 
-func sameName(config1, config2 *rspec.Syscall) bool {
-	return config1.Name == config2.Name
+func sameName(config1, config2 *rspec.LinuxSyscall) bool {
+	return reflect.DeepEqual(config1.Names, config2.Names)
 }
 
-func sameAction(config1, config2 *rspec.Syscall) bool {
+func sameAction(config1, config2 *rspec.LinuxSyscall) bool {
 	return config1.Action == config2.Action
 }
 
-func sameArgs(config1, config2 *rspec.Syscall) bool {
+func sameArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	return reflect.DeepEqual(config1.Args, config2.Args)
 }
 
-func bothHaveArgs(config1, config2 *rspec.Syscall) bool {
+func bothHaveArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	return hasArguments(config1) && hasArguments(config2)
 }
 
-func onlyOneHasArgs(config1, config2 *rspec.Syscall) bool {
+func onlyOneHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	conf1 := hasArguments(config1)
 	conf2 := hasArguments(config2)
 
 	return (conf1 && !conf2) || (!conf1 && conf2)
 }
 
-func neitherHasArgs(config1, config2 *rspec.Syscall) bool {
+func neitherHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	return !hasArguments(config1) && !hasArguments(config2)
 }
 
-func firstParamOnlyHasArgs(config1, config2 *rspec.Syscall) bool {
+func firstParamOnlyHasArgs(config1, config2 *rspec.LinuxSyscall) bool {
 	return !hasArguments(config1) && hasArguments(config2)
 }

--- a/vendor/github.com/opencontainers/runtime-tools/generate/spec.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/spec.go
@@ -34,41 +34,41 @@ func (g *Generator) initSpecLinuxSysctl() {
 func (g *Generator) initSpecLinuxSeccomp() {
 	g.initSpecLinux()
 	if g.spec.Linux.Seccomp == nil {
-		g.spec.Linux.Seccomp = &rspec.Seccomp{}
+		g.spec.Linux.Seccomp = &rspec.LinuxSeccomp{}
 	}
 }
 
 func (g *Generator) initSpecLinuxResources() {
 	g.initSpecLinux()
 	if g.spec.Linux.Resources == nil {
-		g.spec.Linux.Resources = &rspec.Resources{}
+		g.spec.Linux.Resources = &rspec.LinuxResources{}
 	}
 }
 
 func (g *Generator) initSpecLinuxResourcesCPU() {
 	g.initSpecLinuxResources()
 	if g.spec.Linux.Resources.CPU == nil {
-		g.spec.Linux.Resources.CPU = &rspec.CPU{}
+		g.spec.Linux.Resources.CPU = &rspec.LinuxCPU{}
 	}
 }
 
 func (g *Generator) initSpecLinuxResourcesMemory() {
 	g.initSpecLinuxResources()
 	if g.spec.Linux.Resources.Memory == nil {
-		g.spec.Linux.Resources.Memory = &rspec.Memory{}
+		g.spec.Linux.Resources.Memory = &rspec.LinuxMemory{}
 	}
 }
 
 func (g *Generator) initSpecLinuxResourcesNetwork() {
 	g.initSpecLinuxResources()
 	if g.spec.Linux.Resources.Network == nil {
-		g.spec.Linux.Resources.Network = &rspec.Network{}
+		g.spec.Linux.Resources.Network = &rspec.LinuxNetwork{}
 	}
 }
 
 func (g *Generator) initSpecLinuxResourcesPids() {
 	g.initSpecLinuxResources()
 	if g.spec.Linux.Resources.Pids == nil {
-		g.spec.Linux.Resources.Pids = &rspec.Pids{}
+		g.spec.Linux.Resources.Pids = &rspec.LinuxPids{}
 	}
 }


### PR DESCRIPTION
The most recent runC version requires v1.0.0-rc5, which requires some
changes. In addition, runtime-tools needed to be updated. This patch
updates the following vendors:

* github.com/opencontainers/runtime-spec@v1.0.0-rc5
  + runtime-tools-0001-generate-remove-validate-dependency.patch
* github.com/opencontainers/runtime-tools@b081a428c91705169ec3628a10bd5ca9992afea9

This also contains the trivial changes to the names of various types.

Fixes #113
Signed-off-by: Aleksa Sarai <asarai@suse.de>