### PR TITLE
ci: fix EPERM coverage file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ notifications:
     email: false
 
 script:
+  - chmod a+rwx . # Necessary to make Travis co-operate with Docker.
   - make umoci
   - make umoci.static
   - make DOCKER_IMAGE=$DOCKER_IMAGE ci

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ endif
 
 .PHONY: test-unit
 test-unit: umociimage
-	touch $(COVERAGE)
+	touch $(COVERAGE) && chmod a+rw $(COVERAGE)
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) --cap-add=SYS_ADMIN $(UMOCI_IMAGE) make local-test-unit
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-unit
 
@@ -122,7 +122,7 @@ local-test-unit:
 
 .PHONY: test-integration
 test-integration: umociimage
-	touch $(COVERAGE)
+	touch $(COVERAGE) && chmod a+rw $(COVERAGE)
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) $(UMOCI_IMAGE) make local-test-integration
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-integration
 


### PR DESCRIPTION
This recently broke on Travis, and it appears that there's some
mysterious permission issue happening with the interactions between
Docker and the coverage file.

Really we should make the CI not use Docker at all, but the package
requirements are forcing us to use CI for now. Hopefully we can improve
this in the future.

Signed-off-by: Aleksa Sarai <asarai@suse.de>