### PR TITLE
*: update to image-spec v1.0.0-rc5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   program][cii]. openSUSE/umoci#134
 - `umoci` also now has more extensive architecture, quick-start and roadmap
   documentation. openSUSE/umoci#134
+- `umoci` now supports [`1.0.0-rc5` of the OCI image
+  specification][ispec-v1.0.0-rc5]. Note that there are still some remaining UX
+  issues with `--image` and other parts of `umoci` which may be subject to
+  change in future versions. In particular, this update of the specification
+  now means that images may have ambiguous tags. `umoci` will warn you if an
+  operation may have an ambiguous result, but we plan to improve this
+  functionality far more in the future. openSUSE/umoci#133
+
 ### Changed
 - Error messages from `github.com/openSUSE/umoci/oci/cas/drivers/dir` actually
   make sense now. openSUSE/umoci#121
@@ -18,6 +26,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   openSUSE/umoci#120
 
 [cii]: https://bestpractices.coreinfrastructure.org/projects/1084
+[ispec-v1.0.0-rc5]: https://github.com/opencontainers/image-spec/releases/tag/v1.0.0-rc5
 [ispec-pr492]: https://github.com/opencontainers/image-spec/pull/492
 
 ## [0.2.1] - 2017-04-12

--- a/cmd/umoci/new.go
+++ b/cmd/umoci/new.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/openSUSE/umoci/oci/cas"
+	"github.com/openSUSE/umoci/oci/casext"
 	igen "github.com/openSUSE/umoci/oci/config/generate"
 	imeta "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -59,6 +60,7 @@ func newImage(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}
+	engineExt := casext.Engine{engine}
 	defer engine.Close()
 
 	// Create a new manifest.
@@ -82,7 +84,7 @@ func newImage(ctx *cli.Context) error {
 
 	// Update config and create a new blob for it.
 	config := g.Image()
-	configDigest, configSize, err := engine.PutBlobJSON(context.Background(), config)
+	configDigest, configSize, err := engineExt.PutBlobJSON(context.Background(), config)
 	if err != nil {
 		return errors.Wrap(err, "put config blob")
 	}
@@ -106,7 +108,7 @@ func newImage(ctx *cli.Context) error {
 		Layers: []ispec.Descriptor{},
 	}
 
-	manifestDigest, manifestSize, err := engine.PutBlobJSON(context.Background(), manifest)
+	manifestDigest, manifestSize, err := engineExt.PutBlobJSON(context.Background(), manifest)
 	if err != nil {
 		return errors.Wrap(err, "put manifest blob")
 	}

--- a/cmd/umoci/new.go
+++ b/cmd/umoci/new.go
@@ -130,18 +130,7 @@ func newImage(ctx *cli.Context) error {
 
 	log.Infof("new image manifest created: %s", descriptor.Digest)
 
-	err = engine.PutReference(context.Background(), tagName, descriptor)
-	if err == cas.ErrClobber {
-		// We have to clobber a tag.
-		log.Warnf("clobbering existing tag: %s", tagName)
-
-		// Delete the old tag.
-		if err := engine.DeleteReference(context.Background(), tagName); err != nil {
-			return errors.Wrap(err, "delete old tag")
-		}
-		err = engine.PutReference(context.Background(), tagName, descriptor)
-	}
-	if err != nil {
+	if err := engineExt.UpdateReference(context.Background(), tagName, descriptor); err != nil {
 		return errors.Wrap(err, "add new tag")
 	}
 

--- a/cmd/umoci/raw-runtime-config.go
+++ b/cmd/umoci/raw-runtime-config.go
@@ -131,10 +131,15 @@ func rawConfig(ctx *cli.Context) error {
 	engineExt := casext.Engine{engine}
 	defer engine.Close()
 
-	fromDescriptor, err := engineExt.GetReference(context.Background(), fromName)
+	fromDescriptors, err := engineExt.ResolveReference(context.Background(), fromName)
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(fromDescriptors) != 1 {
+		// TODO: Handle this more nicely.
+		return errors.Errorf("tag is ambiguous: %s", fromName)
+	}
+	fromDescriptor := fromDescriptors[0]
 	meta.From = fromDescriptor
 
 	manifestBlob, err := engineExt.FromDescriptor(context.Background(), meta.From)

--- a/cmd/umoci/stat.go
+++ b/cmd/umoci/stat.go
@@ -67,10 +67,15 @@ func stat(ctx *cli.Context) error {
 	engineExt := casext.Engine{engine}
 	defer engine.Close()
 
-	manifestDescriptor, err := engine.GetReference(context.Background(), tagName)
+	manifestDescriptors, err := engineExt.ResolveReference(context.Background(), tagName)
 	if err != nil {
-		return errors.Wrap(err, "get reference")
+		return errors.Wrap(err, "get descriptor")
 	}
+	if len(manifestDescriptors) != 1 {
+		// TODO: Handle this more nicely.
+		return errors.Errorf("tag is ambiguous: %s", tagName)
+	}
+	manifestDescriptor := manifestDescriptors[0]
 
 	// FIXME: Implement support for manifest lists.
 	if manifestDescriptor.MediaType != ispec.MediaTypeImageManifest {

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -129,10 +129,15 @@ func unpack(ctx *cli.Context) error {
 	engineExt := casext.Engine{engine}
 	defer engine.Close()
 
-	fromDescriptor, err := engineExt.GetReference(context.Background(), fromName)
+	fromDescriptors, err := engineExt.ResolveReference(context.Background(), fromName)
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(fromDescriptors) != 1 {
+		// TODO: Handle this more nicely.
+		return errors.Errorf("tag is ambiguous: %s", fromName)
+	}
+	fromDescriptor := fromDescriptors[0]
 	meta.From = fromDescriptor
 
 	manifestBlob, err := engineExt.FromDescriptor(context.Background(), meta.From)

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -117,7 +117,7 @@ clone() {
 # TODO: Put this in a vendor.conf file or something like that (to be compatible
 #       with LK4D4/vndr). This setup is a bit unwieldy.
 clone github.com/opencontainers/go-digest v1.0.0-rc0
-clone github.com/opencontainers/image-spec v1.0.0-rc4
+clone github.com/opencontainers/image-spec v1.0.0-rc5
 clone github.com/opencontainers/runtime-spec v1.0.0-rc5
 clone github.com/opencontainers/image-tools 421458f7e467ac86175408693a07da6d29817bf7
 clone github.com/opencontainers/runtime-tools 2f0b832c731dcacc6ad44b03200a3a6a3e14393e

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/openSUSE/umoci/oci/cas"
+	"github.com/openSUSE/umoci/oci/casext"
 	imeta "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"golang.org/x/net/context"
@@ -52,6 +53,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	engineExt := casext.Engine{engine}
 
 	// Write a tar layer.
 	var buffer bytes.Buffer
@@ -91,7 +93,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 		},
 	}
 
-	configDigest, configSize, err := engine.PutBlobJSON(context.Background(), config)
+	configDigest, configSize, err := engineExt.PutBlobJSON(context.Background(), config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +120,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 		},
 	}
 
-	manifestDigest, manifestSize, err := engine.PutBlobJSON(context.Background(), manifest)
+	manifestDigest, manifestSize, err := engineExt.PutBlobJSON(context.Background(), manifest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -59,18 +59,6 @@ type Engine interface {
 	// of this PutBlob() call".
 	PutBlob(ctx context.Context, reader io.Reader) (digest digest.Digest, size int64, err error)
 
-	// PutBlobJSON adds a new JSON blob to the image (marshalled from the given
-	// interface). This is equivalent to calling PutBlob() with a JSON payload
-	// as the reader. Note that due to intricacies in the Go JSON
-	// implementation, we cannot guarantee that two calls to PutBlobJSON() will
-	// return the same digest.
-	//
-	// TODO: Use a proper JSON serialisation library, which actually guarantees
-	//       consistent output. Go's JSON library doesn't even attempt to sort
-	//       map[...]... objects (which have their iteration order randomised
-	//       in Go).
-	PutBlobJSON(ctx context.Context, data interface{}) (digest digest.Digest, size int64, err error)
-
 	// PutReference adds a new reference descriptor blob to the image. This is
 	// idempotent; a nil error means that "the descriptor is stored at NAME"
 	// without implying "because of this PutReference() call". ErrClobber is

--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -39,6 +39,10 @@ const (
 
 // Exposed errors.
 var (
+	// ErrNotExist is effectively an implementation-neutral version of
+	// os.ErrNotExist.
+	ErrNotExist = fmt.Errorf("no such blob or index")
+
 	// ErrInvalid is returned when an image was detected as being invalid.
 	ErrInvalid = fmt.Errorf("invalid image detected")
 
@@ -59,36 +63,34 @@ type Engine interface {
 	// of this PutBlob() call".
 	PutBlob(ctx context.Context, reader io.Reader) (digest digest.Digest, size int64, err error)
 
-	// PutReference adds a new reference descriptor blob to the image. This is
-	// idempotent; a nil error means that "the descriptor is stored at NAME"
-	// without implying "because of this PutReference() call". ErrClobber is
-	// returned if there is already a descriptor stored at NAME, but does not
-	// match the descriptor requested to be stored.
-	PutReference(ctx context.Context, name string, descriptor ispec.Descriptor) (err error)
-
 	// GetBlob returns a reader for retrieving a blob from the image, which the
-	// caller must Close(). Returns os.ErrNotExist if the digest is not found.
+	// caller must Close(). Returns ErrNotExist if the digest is not found.
 	GetBlob(ctx context.Context, digest digest.Digest) (reader io.ReadCloser, err error)
 
-	// GetReference returns a reference from the image. Returns os.ErrNotExist
-	// if the name was not found.
-	GetReference(ctx context.Context, name string) (descriptor ispec.Descriptor, err error)
+	// PutIndex sets the index of the OCI image to the given index, replacing
+	// the previously existing index. This operation is atomic; any readers
+	// attempting to access the OCI image while it is being modified will only
+	// ever see the new or old index.
+	PutIndex(ctx context.Context, index ispec.ImageIndex) (err error)
+
+	// GetIndex returns the index of the OCI image. Return ErrNotExist if the
+	// digest is not found. If the image doesn't have an index, ErrInvalid is
+	// returned (a valid OCI image MUST have an image index).
+	//
+	// It is not recommended that users of cas.Engine use this interface
+	// directly, due to the complication of properly handling references as
+	// well as correctly handling nested indexes. casext.Engine provides a
+	// wrapper for cas.Engine that implements various reference resolution
+	// functions that should work for most users.
+	GetIndex(ctx context.Context) (index ispec.ImageIndex, ierr error)
 
 	// DeleteBlob removes a blob from the image. This is idempotent; a nil
 	// error means "the content is not in the store" without implying "because
 	// of this DeleteBlob() call".
 	DeleteBlob(ctx context.Context, digest digest.Digest) (err error)
 
-	// DeleteReference removes a reference from the image. This is idempotent;
-	// a nil error means "the content is not in the store" without implying
-	// "because of this DeleteReference() call".
-	DeleteReference(ctx context.Context, name string) (err error)
-
 	// ListBlobs returns the set of blob digests stored in the image.
 	ListBlobs(ctx context.Context) (digests []digest.Digest, err error)
-
-	// ListReferences returns the set of reference names stored in the image.
-	ListReferences(ctx context.Context) (names []string, err error)
 
 	// Clean executes a garbage collection of any non-blob garbage in the store
 	// (this includes temporary files and directories not reachable from the

--- a/oci/cas/drivers/dir/cas_test.go
+++ b/oci/cas/drivers/dir/cas_test.go
@@ -23,11 +23,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/openSUSE/umoci/oci/cas"
-	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -156,66 +154,6 @@ func TestEngineBlob(t *testing.T) {
 		t.Errorf("unexpected error getting list of blobs: %+v", err)
 	} else if len(blobs) > 0 {
 		t.Errorf("got blobs in a clean image: %v", blobs)
-	}
-}
-
-func TestEngineReference(t *testing.T) {
-	ctx := context.Background()
-
-	root, err := ioutil.TempDir("", "umoci-TestEngineReference")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
-
-	image := filepath.Join(root, "image")
-	if err := Create(image); err != nil {
-		t.Fatalf("unexpected error creating image: %+v", err)
-	}
-
-	engine, err := Open(image)
-	if err != nil {
-		t.Fatalf("unexpected error opening image: %+v", err)
-	}
-	defer engine.Close()
-
-	for _, test := range []struct {
-		name       string
-		descriptor ispec.Descriptor
-	}{
-		{"ref1", ispec.Descriptor{}},
-		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
-		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
-	} {
-		if err := engine.PutReference(ctx, test.name, test.descriptor); err != nil {
-			t.Errorf("PutReference: unexpected error: %+v", err)
-		}
-
-		gotDescriptor, err := engine.GetReference(ctx, test.name)
-		if err != nil {
-			t.Errorf("GetReference: unexpected error: %+v", err)
-		}
-
-		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
-			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
-		}
-
-		if err := engine.DeleteReference(ctx, test.name); err != nil {
-			t.Errorf("DeleteReference: unexpected error: %+v", err)
-		}
-
-		if _, err := engine.GetReference(ctx, test.name); !os.IsNotExist(errors.Cause(err)) {
-			if err == nil {
-				t.Errorf("GetReference: still got reference descriptor after DeleteReference!")
-			} else {
-				t.Errorf("GetReference: unexpected error: %+v", err)
-			}
-		}
-
-		// DeleteBlob is idempotent. It shouldn't cause an error.
-		if err := engine.DeleteReference(ctx, test.name); err != nil {
-			t.Errorf("DeleteReference: unexpected error on double-delete: %+v", err)
-		}
 	}
 }
 

--- a/oci/cas/drivers/dir/dir.go
+++ b/oci/cas/drivers/dir/dir.go
@@ -18,7 +18,6 @@
 package dir
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -190,19 +189,6 @@ func (e *dirEngine) PutBlob(ctx context.Context, reader io.Reader) (digest.Diges
 	}
 
 	return digester.Digest(), int64(size), nil
-}
-
-// PutBlobJSON adds a new JSON blob to the image (marshalled from the given
-// interface). This is equivalent to calling PutBlob() with a JSON payload
-// as the reader. Note that due to intricacies in the Go JSON
-// implementation, we cannot guarantee that two calls to PutBlobJSON() will
-// return the same digest.
-func (e *dirEngine) PutBlobJSON(ctx context.Context, data interface{}) (digest.Digest, int64, error) {
-	var buffer bytes.Buffer
-	if err := json.NewEncoder(&buffer).Encode(data); err != nil {
-		return "", -1, errors.Wrap(err, "encode JSON")
-	}
-	return e.PutBlob(ctx, &buffer)
 }
 
 // PutReference adds a new reference descriptor blob to the image. This is

--- a/oci/cas/drivers/dir/dir_test.go
+++ b/oci/cas/drivers/dir/dir_test.go
@@ -23,12 +23,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
 	"syscall"
 	"testing"
 
 	"github.com/openSUSE/umoci/oci/cas"
-	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -181,74 +179,6 @@ func TestEngineBlobReadonly(t *testing.T) {
 		if err == nil {
 			t.Logf("PutBlob: e.temp = %s", newEngine.(*dirEngine).temp)
 			t.Errorf("PutBlob: expected error on ro image!")
-		}
-
-		if err := newEngine.Close(); err != nil {
-			t.Errorf("Close: unexpected error encountered on ro: %+v", err)
-		}
-
-		// make it readwrite again.
-		readwrite(t, image)
-	}
-}
-
-func TestEngineReferenceReadonly(t *testing.T) {
-	ctx := context.Background()
-
-	root, err := ioutil.TempDir("", "umoci-TestEngineReferenceReadonly")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(root)
-
-	image := filepath.Join(root, "image")
-	if err := Create(image); err != nil {
-		t.Fatalf("unexpected error creating image: %+v", err)
-	}
-
-	for _, test := range []struct {
-		name       string
-		descriptor ispec.Descriptor
-	}{
-		{"ref1", ispec.Descriptor{}},
-		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
-		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
-	} {
-
-		engine, err := Open(image)
-		if err != nil {
-			t.Fatalf("unexpected error opening image: %+v", err)
-		}
-
-		if err := engine.PutReference(ctx, test.name, test.descriptor); err != nil {
-			t.Errorf("PutReference: unexpected error: %+v", err)
-		}
-
-		if err := engine.Close(); err != nil {
-			t.Errorf("Close: unexpected error encountered: %+v", err)
-		}
-
-		// make it readonly
-		readonly(t, image)
-
-		newEngine, err := Open(image)
-		if err != nil {
-			t.Errorf("unexpected error opening ro image: %+v", err)
-		}
-
-		gotDescriptor, err := newEngine.GetReference(ctx, test.name)
-		if err != nil {
-			t.Errorf("GetReference: unexpected error: %+v", err)
-		}
-
-		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
-			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
-		}
-
-		// Make sure that writing will FAIL.
-		if err := newEngine.PutReference(ctx, test.name+"new", test.descriptor); err == nil {
-			t.Logf("PutReference: e.temp = %s", newEngine.(*dirEngine).temp)
-			t.Errorf("PutReference: expected error on ro image!")
 		}
 
 		if err := newEngine.Close(); err != nil {

--- a/oci/cas/drivers/dir/dir_test.go
+++ b/oci/cas/drivers/dir/dir_test.go
@@ -91,11 +91,11 @@ func TestCreateLayoutReadonly(t *testing.T) {
 	}
 	defer engine.Close()
 
-	// We should have no references or blobs.
-	if refs, err := engine.ListReferences(ctx); err != nil {
-		t.Errorf("unexpected error getting list of references: %+v", err)
-	} else if len(refs) > 0 {
-		t.Errorf("got references in a newly created image: %v", refs)
+	// We should have an empty index and no blobs.
+	if index, err := engine.GetIndex(ctx); err != nil {
+		t.Errorf("unexpected error getting top-level index: %+v", err)
+	} else if len(index.Manifests) > 0 {
+		t.Errorf("got manifests in top-level index in a newly created image: %v", index.Manifests)
 	}
 	if blobs, err := engine.ListBlobs(ctx); err != nil {
 		t.Errorf("unexpected error getting list of blobs: %+v", err)

--- a/oci/casext/blob.go
+++ b/oci/casext/blob.go
@@ -96,11 +96,11 @@ func (b *Blob) load(ctx context.Context, engine cas.Engine) error {
 		}
 		b.Data = parsed
 
-	// ispec.MediaTypeImageManifestList => ispec.ManifestList
-	case ispec.MediaTypeImageManifestList:
-		parsed := ispec.ManifestList{}
+	// ispec.MediaTypeImageIndex => ispec.ImageIndex
+	case ispec.MediaTypeImageIndex:
+		parsed := ispec.ImageIndex{}
 		if err := json.NewDecoder(reader).Decode(&parsed); err != nil {
-			return errors.Wrap(err, "parse MediaTypeImageManifestList")
+			return errors.Wrap(err, "parse MediaTypeImageImageIndex")
 		}
 		b.Data = parsed
 

--- a/oci/casext/gc.go
+++ b/oci/casext/gc.go
@@ -45,10 +45,16 @@ func (e Engine) GC(ctx context.Context) error {
 	}
 
 	for _, name := range names {
-		descriptor, err := e.GetReference(ctx, name)
+		// TODO: This code is no longer necessary once we have index.json.
+		descriptors, err := e.ResolveReference(ctx, name)
 		if err != nil {
 			return errors.Wrapf(err, "get root %s", name)
 		}
+		if len(descriptors) != 1 {
+			// TODO: Handle this more nicely.
+			return errors.Errorf("tag is ambiguous: %s", name)
+		}
+		descriptor := descriptors[0]
 		log.WithFields(log.Fields{
 			"name":   name,
 			"digest": descriptor.Digest,

--- a/oci/casext/json.go
+++ b/oci/casext/json.go
@@ -1,0 +1,45 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2017 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+// PutBlobJSON adds a new JSON blob to the image (marshalled from the given
+// interface). This is equivalent to calling PutBlob() with a JSON payload
+// as the reader. Note that due to intricacies in the Go JSON
+// implementation, we cannot guarantee that two calls to PutBlobJSON() will
+// return the same digest.
+//
+// TODO: Use a proper JSON serialisation library, which actually guarantees
+//       consistent output. Go's JSON library doesn't even attempt to sort
+//       map[...]... objects (which have their iteration order randomised in
+//       Go).
+func (e Engine) PutBlobJSON(ctx context.Context, data interface{}) (digest.Digest, int64, error) {
+	var buffer bytes.Buffer
+	if err := json.NewEncoder(&buffer).Encode(data); err != nil {
+		return "", -1, errors.Wrap(err, "encode JSON")
+	}
+	return e.PutBlob(ctx, &buffer)
+}

--- a/oci/casext/json_dir_test.go
+++ b/oci/casext/json_dir_test.go
@@ -1,0 +1,200 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016, 2017 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openSUSE/umoci/oci/cas"
+	_ "github.com/openSUSE/umoci/oci/cas/drivers"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func TestEngineBlobJSON(t *testing.T) {
+	ctx := context.Background()
+
+	root, err := ioutil.TempDir("", "umoci-TestEngineBlobJSON")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := cas.Create(image); err != nil {
+		t.Fatalf("unexpected error creating image: %+v", err)
+	}
+
+	engine, err := cas.Open(image)
+	if err != nil {
+		t.Fatalf("unexpected error opening image: %+v", err)
+	}
+	engineExt := Engine{engine}
+	defer engine.Close()
+
+	type object struct {
+		A string `json:"A"`
+		B int64  `json:"B,omitempty"`
+	}
+
+	for _, test := range []struct {
+		object object
+	}{
+		{object{}},
+		{object{"a value", 100}},
+		{object{"another value", 200}},
+	} {
+		digest, _, err := engineExt.PutBlobJSON(ctx, test.object)
+		if err != nil {
+			t.Errorf("PutBlobJSON: unexpected error: %+v", err)
+		}
+
+		blobReader, err := engine.GetBlob(ctx, digest)
+		if err != nil {
+			t.Errorf("GetBlob: unexpected error: %+v", err)
+		}
+		defer blobReader.Close()
+
+		gotBytes, err := ioutil.ReadAll(blobReader)
+		if err != nil {
+			t.Errorf("GetBlob: failed to ReadAll: %+v", err)
+		}
+
+		var gotObject object
+		if err := json.Unmarshal(gotBytes, &gotObject); err != nil {
+			t.Errorf("GetBlob: got an invalid JSON blob: %+v", err)
+		}
+		if !reflect.DeepEqual(test.object, gotObject) {
+			t.Errorf("GetBlob: got different object to original JSON. expected=%v got=%v gotBytes=%v", test.object, gotObject, gotBytes)
+		}
+
+		if err := engine.DeleteBlob(ctx, digest); err != nil {
+			t.Errorf("DeleteBlob: unexpected error: %+v", err)
+		}
+
+		if br, err := engine.GetBlob(ctx, digest); !os.IsNotExist(errors.Cause(err)) {
+			if err == nil {
+				br.Close()
+				t.Errorf("GetBlob: still got blob contents after DeleteBlob!")
+			} else {
+				t.Errorf("GetBlob: unexpected error: %+v", err)
+			}
+		}
+
+		// DeleteBlob is idempotent. It shouldn't cause an error.
+		if err := engine.DeleteBlob(ctx, digest); err != nil {
+			t.Errorf("DeleteBlob: unexpected error on double-delete: %+v", err)
+		}
+	}
+
+	// Should be no blobs left.
+	if blobs, err := engine.ListBlobs(ctx); err != nil {
+		t.Errorf("unexpected error getting list of blobs: %+v", err)
+	} else if len(blobs) > 0 {
+		t.Errorf("got blobs in a clean image: %v", blobs)
+	}
+}
+
+func TestEngineBlobJSONReadonly(t *testing.T) {
+	ctx := context.Background()
+
+	root, err := ioutil.TempDir("", "umoci-TestEngineBlobJSONReadonly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := cas.Create(image); err != nil {
+		t.Fatalf("unexpected error creating image: %+v", err)
+	}
+
+	type object struct {
+		A string `json:"A"`
+		B int64  `json:"B,omitempty"`
+	}
+
+	for _, test := range []struct {
+		object object
+	}{
+		{object{}},
+		{object{"a value", 100}},
+		{object{"another value", 200}},
+	} {
+		engine, err := cas.Open(image)
+		if err != nil {
+			t.Fatalf("unexpected error opening image: %+v", err)
+		}
+		engineExt := Engine{engine}
+
+		digest, _, err := engineExt.PutBlobJSON(ctx, test.object)
+		if err != nil {
+			t.Errorf("PutBlobJSON: unexpected error: %+v", err)
+		}
+
+		if err := engine.Close(); err != nil {
+			t.Errorf("Close: unexpected error encountered: %+v", err)
+		}
+
+		// make it readonly
+		readonly(t, image)
+
+		newEngine, err := cas.Open(image)
+		if err != nil {
+			t.Errorf("unexpected error opening ro image: %+v", err)
+		}
+		newEngineExt := Engine{newEngine}
+
+		blobReader, err := newEngineExt.GetBlob(ctx, digest)
+		if err != nil {
+			t.Errorf("GetBlob: unexpected error: %+v", err)
+		}
+		defer blobReader.Close()
+
+		gotBytes, err := ioutil.ReadAll(blobReader)
+		if err != nil {
+			t.Errorf("GetBlob: failed to ReadAll: %+v", err)
+		}
+
+		var gotObject object
+		if err := json.Unmarshal(gotBytes, &gotObject); err != nil {
+			t.Errorf("GetBlob: got an invalid JSON blob: %+v", err)
+		}
+		if !reflect.DeepEqual(test.object, gotObject) {
+			t.Errorf("GetBlob: got different object to original JSON. expected=%v got=%v gotBytes=%v", test.object, gotObject, gotBytes)
+		}
+
+		// Make sure that writing again will FAIL.
+		_, _, err = newEngineExt.PutBlobJSON(ctx, test.object)
+		if err == nil {
+			t.Errorf("PutBlob: expected error on ro image!")
+		}
+
+		if err := newEngine.Close(); err != nil {
+			t.Errorf("Close: unexpected error encountered on ro: %+v", err)
+		}
+
+		// make it readwrite again.
+		readwrite(t, image)
+	}
+}

--- a/oci/casext/refname.go
+++ b/oci/casext/refname.go
@@ -1,0 +1,75 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2017 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"github.com/apex/log"
+	"github.com/openSUSE/umoci/oci/cas"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+// XXX: This is a temporary implementation that will be replaced with the move
+//      to 1.0.0-rc5. You really shouldn't hit any bugs on this commit.
+
+// ResolveReference is a wrapper around GetReference.
+func (e Engine) ResolveReference(ctx context.Context, refname string) ([]ispec.Descriptor, error) {
+	descriptor, err := e.GetReference(ctx, refname)
+	if err != nil {
+		return nil, err
+	}
+	// XXX: This is wrong for ImageManifests. However,
+	return []ispec.Descriptor{descriptor}, nil
+}
+
+// UpdateReference is just a wrapper around PutReference.
+func (e Engine) UpdateReference(ctx context.Context, refname string, descriptor ispec.Descriptor) error {
+	err := e.PutReference(ctx, refname, descriptor)
+	// TODO: This won't ever be hit with v1.0.0-rc5.
+	if err == cas.ErrClobber {
+		// We have to clobber a tag.
+		log.Warnf("clobbering existing tag: %s", refname)
+
+		// Delete the old tag.
+		if err := e.DeleteReference(ctx, refname); err != nil {
+			return errors.Wrap(err, "delete old tag")
+		}
+		err = e.PutReference(ctx, refname, descriptor)
+	}
+	return err
+}
+
+// AddReferences is just a wrapper around PutReference.
+func (e Engine) AddReferences(ctx context.Context, refname string, descriptors ...ispec.Descriptor) error {
+	if len(descriptors) != 1 {
+		// XXX: This is not supported by v1.0.0-rc4 of the image-spec.
+		return errors.Errorf("can only have a single descriptor for each refname")
+	}
+	return e.UpdateReference(ctx, refname, descriptors[0])
+}
+
+// DeleteReference is just a wrapper around DeleteReference.
+func (e Engine) DeleteReference(ctx context.Context, refname string) error {
+	return e.Engine.DeleteReference(ctx, refname)
+}
+
+// ListReferences is just a wrapper around ListReferences.
+func (e Engine) ListReferences(ctx context.Context) ([]string, error) {
+	return e.Engine.ListReferences(ctx)
+}

--- a/oci/casext/refname.go
+++ b/oci/casext/refname.go
@@ -19,57 +19,208 @@ package casext
 
 import (
 	"github.com/apex/log"
-	"github.com/openSUSE/umoci/oci/cas"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
-// XXX: This is a temporary implementation that will be replaced with the move
-//      to 1.0.0-rc5. You really shouldn't hit any bugs on this commit.
+// refAnnotation is defined by the OCI spec to be the reserved annotation for
+// reference names. There is no strong top-level concept of references, so this
+// is the closest we can get.
+// XXX: Make sure this gets updated with 1.0.0-rc6, where this was changed.
+const refAnnotation = "org.opencontainers.ref.name"
 
-// ResolveReference is a wrapper around GetReference.
+// isKnownMediaType returns whether a media type is known by the spec. This
+// probably should be moved somewhere else to avoid going out of date.
+func isKnownMediaType(mediaType string) bool {
+	return mediaType == ispec.MediaTypeDescriptor ||
+		mediaType == ispec.MediaTypeImageManifest ||
+		mediaType == ispec.MediaTypeImageIndex ||
+		mediaType == ispec.MediaTypeImageLayer ||
+		mediaType == ispec.MediaTypeImageLayerGzip ||
+		mediaType == ispec.MediaTypeImageLayerNonDistributable ||
+		mediaType == ispec.MediaTypeImageLayerNonDistributableGzip ||
+		mediaType == ispec.MediaTypeImageConfig
+}
+
+// ResolveReference will attempt to resolve all possible descriptor paths to
+// Manifests (or any unknown blobs) that match a particular reference name (if
+// descriptors are stored in non-standard blobs, Resolve will be unable to find
+// them but will return the top-most unknown descriptor).
+// ResolveReference assumes that "reference name" refers to the value of the
+// "org.opencontainers.ref.name" descriptor annotation. It is recommended that
+// if the returned slice of descriptors is greater than zero that the user be
+// consulted to resolve the conflict (due to ambiguity in resolution paths).
+//
+// TODO: How are we meant to implement other restrictions such as the
+//       architecture and feature flags? The API will need to change.
 func (e Engine) ResolveReference(ctx context.Context, refname string) ([]ispec.Descriptor, error) {
-	descriptor, err := e.GetReference(ctx, refname)
+	index, err := e.GetIndex(ctx)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "get top-level index")
 	}
-	// XXX: This is wrong for ImageManifests. However,
-	return []ispec.Descriptor{descriptor}, nil
-}
 
-// UpdateReference is just a wrapper around PutReference.
-func (e Engine) UpdateReference(ctx context.Context, refname string, descriptor ispec.Descriptor) error {
-	err := e.PutReference(ctx, refname, descriptor)
-	// TODO: This won't ever be hit with v1.0.0-rc5.
-	if err == cas.ErrClobber {
-		// We have to clobber a tag.
-		log.Warnf("clobbering existing tag: %s", refname)
+	// Set of root links that match the given refname.
+	var roots []ispec.Descriptor
 
-		// Delete the old tag.
-		if err := e.DeleteReference(ctx, refname); err != nil {
-			return errors.Wrap(err, "delete old tag")
+	// We only consider the case where refAnnotation is defined on the
+	// top-level of the index tree. While this isn't codified in the spec (at
+	// the time of writing -- 1.0.0-rc5) there are some discussions to add this
+	// restriction in 1.0.0-rc6.
+	for _, descriptor := range index.Manifests {
+		// XXX: What should we do if refname == "".
+		if descriptor.Annotations[refAnnotation] == refname {
+			roots = append(roots, descriptor.Descriptor)
 		}
-		err = e.PutReference(ctx, refname, descriptor)
 	}
-	return err
+
+	// The resolved set of descriptors.
+	var resolutions []ispec.Descriptor
+	for _, root := range roots {
+		// Find all manifests or other blobs that are reachable from the given
+		// descriptor.
+		if err := e.Walk(ctx, root, func(descriptor ispec.Descriptor) error {
+			// It is very important that we do not ignore unknown media types
+			// here. We only recurse into mediaTypes that are *known* and are
+			// also not ispec.MediaTypeImageManifest.
+			if isKnownMediaType(descriptor.MediaType) && descriptor.MediaType != ispec.MediaTypeImageManifest {
+				return nil
+			}
+
+			// Add the resolution and do not recurse any deeper.
+			resolutions = append(resolutions, descriptor)
+			return ErrSkipDescriptor
+		}); err != nil {
+			return nil, errors.Wrapf(err, "walk %s", root.Digest)
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"refs": resolutions,
+	}).Debugf("casext.ResolveReference(%s) got these descriptors", refname)
+	return resolutions, nil
 }
 
-// AddReferences is just a wrapper around PutReference.
+// UpdateReference replaces an existing entry for refname with the given
+// descriptor. If there are multiple descriptors that match the refname they
+// are all replaced with the given descriptor.
+func (e Engine) UpdateReference(ctx context.Context, refname string, descriptor ispec.Descriptor) error {
+	// Get index to modify.
+	index, err := e.GetIndex(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get top-level index")
+	}
+
+	// TODO: Handle refname = "".
+	var newIndex []ispec.ManifestDescriptor
+	for _, descriptor := range index.Manifests {
+		if descriptor.Annotations[refAnnotation] != refname {
+			newIndex = append(newIndex, descriptor)
+		}
+	}
+	if len(newIndex)-len(index.Manifests) > 1 {
+		// Warn users if the operation is going to remove more than one references.
+		log.Warn("multiple references match the given reference name -- all of them have been replaced due to this ambiguity")
+	}
+
+	// Append the descriptor.
+	if descriptor.Annotations == nil {
+		descriptor.Annotations = map[string]string{}
+	}
+	descriptor.Annotations[refAnnotation] = refname
+	newIndex = append(newIndex, ispec.ManifestDescriptor{Descriptor: descriptor})
+
+	// Commit to image.
+	index.Manifests = newIndex
+	if err := e.PutIndex(ctx, index); err != nil {
+		return errors.Wrap(err, "replace index")
+	}
+	return nil
+}
+
+// AddReferences adds entries for refname with the given descriptors, without
+// modifying the existing entries.
 func (e Engine) AddReferences(ctx context.Context, refname string, descriptors ...ispec.Descriptor) error {
-	if len(descriptors) != 1 {
-		// XXX: This is not supported by v1.0.0-rc4 of the image-spec.
-		return errors.Errorf("can only have a single descriptor for each refname")
+	if len(descriptors) == 0 {
+		// Nothing to do.
+		return nil
 	}
-	return e.UpdateReference(ctx, refname, descriptors[0])
+
+	// Get index to modify.
+	index, err := e.GetIndex(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get top-level index")
+	}
+
+	if len(descriptors) > 1 {
+		// Warn users that they're intentionally creating ambiguous images.
+		log.Warn("umoci has been requested to add multiple descriptors with the same reference name -- this is intentionally creating ambiguity in the OCI image that some tools may be unable to resolve")
+	}
+
+	// Modify the descriptors so that they have the right refname.
+	// TODO: Handle refname = "".
+	var convertedDescriptors []ispec.ManifestDescriptor
+	for _, descriptor := range descriptors {
+		if descriptor.Annotations == nil {
+			descriptor.Annotations = map[string]string{}
+		}
+		descriptor.Annotations[refAnnotation] = refname
+		convertedDescriptors = append(convertedDescriptors, ispec.ManifestDescriptor{Descriptor: descriptor})
+	}
+
+	// Commit to image.
+	index.Manifests = append(index.Manifests, convertedDescriptors...)
+	if err := e.PutIndex(ctx, index); err != nil {
+		return errors.Wrap(err, "replace index")
+	}
+	return nil
 }
 
-// DeleteReference is just a wrapper around DeleteReference.
+// DeleteReference removes all entries in the index that match the given
+// refname.
 func (e Engine) DeleteReference(ctx context.Context, refname string) error {
-	return e.Engine.DeleteReference(ctx, refname)
+	// Get index to modify.
+	index, err := e.GetIndex(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get top-level index")
+	}
+
+	// TODO: Handle refname = "".
+	var newIndex []ispec.ManifestDescriptor
+	for _, descriptor := range index.Manifests {
+		if descriptor.Annotations[refAnnotation] != refname {
+			newIndex = append(newIndex, descriptor)
+		}
+	}
+	if len(newIndex)-len(index.Manifests) > 1 {
+		// Warn users if the operation is going to remove more than one references.
+		log.Warn("multiple references match the given reference name -- all of them have been deleted due to this ambiguity")
+	}
+
+	// Commit to image.
+	index.Manifests = newIndex
+	if err := e.PutIndex(ctx, index); err != nil {
+		return errors.Wrap(err, "replace index")
+	}
+	return nil
 }
 
-// ListReferences is just a wrapper around ListReferences.
+// ListReferences returns all of the ref.name entries that are specified in the
+// top-level index. Note that the list may contain duplicates, due to the
+// nature of references in the image-spec.
 func (e Engine) ListReferences(ctx context.Context) ([]string, error) {
-	return e.Engine.ListReferences(ctx)
+	// Get index.
+	index, err := e.GetIndex(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get top-level index")
+	}
+
+	var refs []string
+	for _, descriptor := range index.Manifests {
+		ref, ok := descriptor.Annotations[refAnnotation]
+		if ok {
+			refs = append(refs, ref)
+		}
+	}
+	return refs, nil
 }

--- a/oci/casext/refname_dir_test.go
+++ b/oci/casext/refname_dir_test.go
@@ -1,0 +1,169 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016, 2017 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openSUSE/umoci/oci/cas"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func TestEngineReference(t *testing.T) {
+	ctx := context.Background()
+
+	root, err := ioutil.TempDir("", "umoci-TestEngineReference")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := cas.Create(image); err != nil {
+		t.Fatalf("unexpected error creating image: %+v", err)
+	}
+
+	engine, err := cas.Open(image)
+	if err != nil {
+		t.Fatalf("unexpected error opening image: %+v", err)
+	}
+	engineExt := Engine{engine}
+	defer engine.Close()
+
+	for _, test := range []struct {
+		name       string
+		descriptor ispec.Descriptor
+	}{
+		{"ref1", ispec.Descriptor{}},
+		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
+		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
+	} {
+		if err := engineExt.UpdateReference(ctx, test.name, test.descriptor); err != nil {
+			t.Errorf("PutReference: unexpected error: %+v", err)
+		}
+
+		gotDescriptors, err := engineExt.ResolveReference(ctx, test.name)
+		if err != nil {
+			t.Errorf("GetReference: unexpected error: %+v", err)
+		}
+		if len(gotDescriptors) != 1 {
+			t.Errorf("GetReference: expected to get %d descriptors, got %d", 1, len(gotDescriptors))
+		}
+		gotDescriptor := gotDescriptors[0]
+
+		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
+			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
+		}
+
+		if err := engineExt.DeleteReference(ctx, test.name); err != nil {
+			t.Errorf("DeleteReference: unexpected error: %+v", err)
+		}
+
+		if _, err := engineExt.ResolveReference(ctx, test.name); !os.IsNotExist(errors.Cause(err)) {
+			if err == nil {
+				t.Errorf("GetReference: still got reference descriptor after DeleteReference!")
+			} else {
+				t.Errorf("GetReference: unexpected error: %+v", err)
+			}
+		}
+
+		// DeleteBlob is idempotent. It shouldn't cause an error.
+		if err := engineExt.DeleteReference(ctx, test.name); err != nil {
+			t.Errorf("DeleteReference: unexpected error on double-delete: %+v", err)
+		}
+	}
+}
+
+func TestEngineReferenceReadonly(t *testing.T) {
+	ctx := context.Background()
+
+	root, err := ioutil.TempDir("", "umoci-TestEngineReferenceReadonly")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	image := filepath.Join(root, "image")
+	if err := cas.Create(image); err != nil {
+		t.Fatalf("unexpected error creating image: %+v", err)
+	}
+
+	for _, test := range []struct {
+		name       string
+		descriptor ispec.Descriptor
+	}{
+		{"ref1", ispec.Descriptor{}},
+		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
+		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
+	} {
+
+		engine, err := cas.Open(image)
+		if err != nil {
+			t.Fatalf("unexpected error opening image: %+v", err)
+		}
+		engineExt := Engine{engine}
+
+		if err := engineExt.UpdateReference(ctx, test.name, test.descriptor); err != nil {
+			t.Errorf("PutReference: unexpected error: %+v", err)
+		}
+
+		if err := engine.Close(); err != nil {
+			t.Errorf("Close: unexpected error encountered: %+v", err)
+		}
+
+		// make it readonly
+		readonly(t, image)
+
+		newEngine, err := cas.Open(image)
+		if err != nil {
+			t.Errorf("unexpected error opening ro image: %+v", err)
+		}
+		newEngineExt := Engine{engine}
+
+		gotDescriptors, err := newEngineExt.ResolveReference(ctx, test.name)
+		if err != nil {
+			t.Errorf("GetReference: unexpected error: %+v", err)
+		}
+		if len(gotDescriptors) != 1 {
+			t.Errorf("GetReference: expected to get %d descriptors, got %d", 1, len(gotDescriptors))
+		}
+		gotDescriptor := gotDescriptors[0]
+
+		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
+			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
+		}
+
+		// Make sure that writing will FAIL.
+		if err := newEngineExt.UpdateReference(ctx, test.name+"new", test.descriptor); err == nil {
+			t.Errorf("PutReference: expected error on ro image!")
+		}
+
+		if err := newEngine.Close(); err != nil {
+			t.Errorf("Close: unexpected error encountered on ro: %+v", err)
+		}
+
+		// make it readwrite again.
+		readwrite(t, image)
+	}
+}

--- a/oci/casext/refname_dir_test.go
+++ b/oci/casext/refname_dir_test.go
@@ -18,17 +18,255 @@
 package casext
 
 import (
+	"archive/tar"
+	"bytes"
+	crand "crypto/rand"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/openSUSE/umoci/oci/cas"
+	"github.com/opencontainers/go-digest"
+	ispecs "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
+
+type descriptorMap struct {
+	index  ispec.Descriptor
+	result ispec.Descriptor
+}
+
+func randomString(n int) string {
+	const alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alpha[rand.Intn(len(alpha))]
+	}
+	return string(b)
+}
+
+func randomTarData(t *testing.T, tw *tar.Writer) error {
+	// Add some files with random contents and random names.
+	for n := 0; n < 32; n++ {
+		size := rand.Intn(512 * 1024)
+
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     randomString(16),
+			Mode:     0755,
+			Uid:      rand.Intn(1337),
+			Gid:      rand.Intn(1337),
+			Size:     int64(size),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			return fmt.Errorf("randomTarData WriteHeader %d", n)
+		}
+		if _, err := io.CopyN(tw, crand.Reader, int64(size)); err != nil {
+			return fmt.Errorf("randomTarData Write %d", n)
+		}
+	}
+	return nil
+}
+
+// fakeSetupEngine injects a variety of "fake" blobs which may not include a
+// full blob tree to test whether Walk and ResolveReference act sanely in the
+// face of unknown media types as well as arbitrary nesting of known media
+// types. The returned
+func fakeSetupEngine(t *testing.T, engineExt Engine) ([]descriptorMap, error) {
+	ctx := context.Background()
+	/*
+		for _, test := range []struct {
+			name       string
+			descriptor ispec.Descriptor
+		}{
+			{"ref1", ispec.Descriptor{}},
+			{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
+			{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
+		} {
+		}
+	*/
+
+	mapping := []descriptorMap{}
+
+	// Add some "normal" images that contain some layers and also have some
+	// index indirects. The multiple layers makes sure that we don't break the
+	// multi-level resolution.
+	// XXX: In future we'll have to make tests for platform matching.
+	for k := 0; k < 5; k++ {
+		n := 3
+		name := fmt.Sprintf("img_%d", k)
+
+		layerData := make([]bytes.Buffer, n)
+
+		// Generate layer data.
+		for idx := range layerData {
+			tw := tar.NewWriter(&layerData[idx])
+			if err := randomTarData(t, tw); err != nil {
+				t.Fatalf("%s: error generating layer%d data: %+v", name, idx, err)
+			}
+			tw.Close()
+		}
+
+		// Insert all of the layers.
+		layerDescriptors := make([]ispec.Descriptor, n)
+		for idx, layer := range layerData {
+			digest, size, err := engineExt.PutBlob(ctx, &layer)
+			if err != nil {
+				t.Fatalf("%s: error putting layer%d blob: %+v", name, idx, err)
+			}
+			layerDescriptors[idx] = ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageLayer,
+				Digest:    digest,
+				Size:      size,
+			}
+		}
+
+		// Create our config and insert it.
+		configDigest, configSize, err := engineExt.PutBlobJSON(ctx, ispec.Image{
+			Created:      time.Now(),
+			Author:       "Jane Author <janesmith@example.com>",
+			Architecture: runtime.GOARCH,
+			OS:           runtime.GOOS,
+			RootFS: ispec.RootFS{
+				Type: "unknown",
+			},
+		})
+		if err != nil {
+			t.Fatalf("%s: error putting config blob: %+v", name, err)
+		}
+		configDescriptor := ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageConfig,
+			Digest:    configDigest,
+			Size:      configSize,
+		}
+
+		// Create our manifest and insert it.
+		manifest := ispec.Manifest{
+			Versioned: ispecs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: configDescriptor,
+		}
+		for _, layer := range layerDescriptors {
+			manifest.Layers = append(manifest.Layers, layer)
+		}
+
+		manifestDigest, manifestSize, err := engineExt.PutBlobJSON(ctx, manifest)
+		if err != nil {
+			t.Fatalf("%s: error putting manifest blob: %+v", name, err)
+		}
+		manifestDescriptor := ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageManifest,
+			Digest:    manifestDigest,
+			Size:      manifestSize,
+			Annotations: map[string]string{
+				"name": name,
+			},
+		}
+
+		// Add extra index layers.
+		indexDescriptor := manifestDescriptor
+		for i := 0; i < k; i++ {
+			newIndex := ispec.ImageIndex{
+				Versioned: ispecs.Versioned{
+					SchemaVersion: 2,
+				},
+				Manifests: []ispec.ManifestDescriptor{{
+					Descriptor: indexDescriptor,
+					Platform: ispec.Platform{
+						Architecture: runtime.GOARCH,
+						OS:           runtime.GOOS,
+					},
+				}},
+			}
+			indexDigest, indexSize, err := engineExt.PutBlobJSON(ctx, newIndex)
+			if err != nil {
+				t.Fatalf("%s: error putting index-%d blob: %+v", name, i, err)
+			}
+			indexDescriptor = ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageIndex,
+				Digest:    indexDigest,
+				Size:      indexSize,
+			}
+		}
+
+		mapping = append(mapping, descriptorMap{
+			index:  indexDescriptor,
+			result: manifestDescriptor,
+		})
+	}
+
+	// Add some blobs that have unknown mediaTypes. This is loosely based on
+	// the previous section.
+	for k := 0; k < 5; k++ {
+		name := fmt.Sprintf("img_%d", k)
+
+		type fakeManifest struct {
+			Descriptor ispec.Descriptor `json:"descriptor"`
+			Data       []byte           `json:"data"`
+		}
+
+		manifestDigest, manifestSize, err := engineExt.PutBlobJSON(ctx, fakeManifest{
+			Descriptor: ispec.Descriptor{
+				MediaType: "org.opensuse.fake.data",
+				Digest:    digest.SHA256.FromString("Hello, world!"),
+				Size:      0,
+			},
+			Data: []byte("Hello, world!"),
+		})
+		if err != nil {
+			t.Fatalf("%s: error putting manifest blob: %+v", name, err)
+		}
+		manifestDescriptor := ispec.Descriptor{
+			MediaType: "org.opensuse.fake.manifest",
+			Digest:    manifestDigest,
+			Size:      manifestSize,
+			Annotations: map[string]string{
+				"name": name,
+			},
+		}
+
+		// Add extra index layers.
+		indexDescriptor := manifestDescriptor
+		for i := 0; i < k; i++ {
+			newIndex := ispec.ImageIndex{
+				Versioned: ispecs.Versioned{
+					SchemaVersion: 2,
+				},
+				Manifests: []ispec.ManifestDescriptor{{
+					Descriptor: indexDescriptor,
+					Platform: ispec.Platform{
+						Architecture: runtime.GOARCH,
+						OS:           runtime.GOOS,
+					},
+				}},
+			}
+			indexDigest, indexSize, err := engineExt.PutBlobJSON(ctx, newIndex)
+			if err != nil {
+				t.Fatalf("%s: error putting index-%d blob: %+v", name, i, err)
+			}
+			indexDescriptor = ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageIndex,
+				Digest:    indexDigest,
+				Size:      indexSize,
+			}
+		}
+
+		mapping = append(mapping, descriptorMap{
+			index:  indexDescriptor,
+			result: manifestDescriptor,
+		})
+	}
+
+	return mapping, nil
+}
 
 func TestEngineReference(t *testing.T) {
 	ctx := context.Background()
@@ -51,45 +289,44 @@ func TestEngineReference(t *testing.T) {
 	engineExt := Engine{engine}
 	defer engine.Close()
 
-	for _, test := range []struct {
-		name       string
-		descriptor ispec.Descriptor
-	}{
-		{"ref1", ispec.Descriptor{}},
-		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
-		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
-	} {
-		if err := engineExt.UpdateReference(ctx, test.name, test.descriptor); err != nil {
-			t.Errorf("PutReference: unexpected error: %+v", err)
+	descMap, err := fakeSetupEngine(t, engineExt)
+	if err != nil {
+		t.Fatalf("unexpected error doing fakeSetupEngine: %+v", err)
+	}
+
+	for idx, test := range descMap {
+		name := fmt.Sprintf("new_tag_%d", idx)
+
+		if err := engineExt.UpdateReference(ctx, name, test.index); err != nil {
+			t.Errorf("UpdateReference: unexpected error: %+v", err)
 		}
 
-		gotDescriptors, err := engineExt.ResolveReference(ctx, test.name)
+		gotDescriptors, err := engineExt.ResolveReference(ctx, name)
 		if err != nil {
-			t.Errorf("GetReference: unexpected error: %+v", err)
+			t.Errorf("ResolveReference: unexpected error: %+v", err)
 		}
 		if len(gotDescriptors) != 1 {
-			t.Errorf("GetReference: expected to get %d descriptors, got %d", 1, len(gotDescriptors))
+			t.Errorf("ResolveReference: expected %q to get %d descriptors, got %d: %+v", name, 1, len(gotDescriptors), gotDescriptors)
+			continue
 		}
 		gotDescriptor := gotDescriptors[0]
 
-		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
-			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
+		if !reflect.DeepEqual(test.result, gotDescriptor) {
+			t.Errorf("ResolveReference: got different descriptor to original: expected=%v got=%v", test.result, gotDescriptor)
 		}
 
-		if err := engineExt.DeleteReference(ctx, test.name); err != nil {
+		if err := engineExt.DeleteReference(ctx, name); err != nil {
 			t.Errorf("DeleteReference: unexpected error: %+v", err)
 		}
 
-		if _, err := engineExt.ResolveReference(ctx, test.name); !os.IsNotExist(errors.Cause(err)) {
-			if err == nil {
-				t.Errorf("GetReference: still got reference descriptor after DeleteReference!")
-			} else {
-				t.Errorf("GetReference: unexpected error: %+v", err)
-			}
+		if gotDescriptors, err := engineExt.ResolveReference(ctx, name); err != nil {
+			t.Errorf("ResolveReference: unexpected error: %+v", err)
+		} else if len(gotDescriptors) > 0 {
+			t.Errorf("ResolveReference: still got reference descriptors after DeleteReference!")
 		}
 
 		// DeleteBlob is idempotent. It shouldn't cause an error.
-		if err := engineExt.DeleteReference(ctx, test.name); err != nil {
+		if err := engineExt.DeleteReference(ctx, name); err != nil {
 			t.Errorf("DeleteReference: unexpected error on double-delete: %+v", err)
 		}
 	}
@@ -109,14 +346,23 @@ func TestEngineReferenceReadonly(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	for _, test := range []struct {
-		name       string
-		descriptor ispec.Descriptor
-	}{
-		{"ref1", ispec.Descriptor{}},
-		{"ref2", ispec.Descriptor{MediaType: ispec.MediaTypeImageConfig, Digest: "sha256:032581de4629652b8653e4dbb2762d0733028003f1fc8f9edd61ae8181393a15", Size: 100}},
-		{"ref3", ispec.Descriptor{MediaType: ispec.MediaTypeImageLayerNonDistributableGzip, Digest: "sha256:3c968ad60d3a2a72a12b864fa1346e882c32690cbf3bf3bc50ee0d0e4e39f342", Size: 8888}},
-	} {
+	engine, err := cas.Open(image)
+	if err != nil {
+		t.Fatalf("unexpected error opening image: %+v", err)
+	}
+	engineExt := Engine{engine}
+
+	descMap, err := fakeSetupEngine(t, engineExt)
+	if err != nil {
+		t.Fatalf("unexpected error doing fakeSetupEngine: %+v", err)
+	}
+
+	if err := engine.Close(); err != nil {
+		t.Fatalf("unexpected error closing image: %+v", err)
+	}
+
+	for idx, test := range descMap {
+		name := fmt.Sprintf("new_tag_%d", idx)
 
 		engine, err := cas.Open(image)
 		if err != nil {
@@ -124,8 +370,8 @@ func TestEngineReferenceReadonly(t *testing.T) {
 		}
 		engineExt := Engine{engine}
 
-		if err := engineExt.UpdateReference(ctx, test.name, test.descriptor); err != nil {
-			t.Errorf("PutReference: unexpected error: %+v", err)
+		if err := engineExt.UpdateReference(ctx, name, test.index); err != nil {
+			t.Errorf("UpdateReference: unexpected error: %+v", err)
 		}
 
 		if err := engine.Close(); err != nil {
@@ -139,24 +385,24 @@ func TestEngineReferenceReadonly(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error opening ro image: %+v", err)
 		}
-		newEngineExt := Engine{engine}
+		newEngineExt := Engine{newEngine}
 
-		gotDescriptors, err := newEngineExt.ResolveReference(ctx, test.name)
+		gotDescriptors, err := newEngineExt.ResolveReference(ctx, name)
 		if err != nil {
-			t.Errorf("GetReference: unexpected error: %+v", err)
+			t.Errorf("ResolveReference: unexpected error: %+v", err)
 		}
 		if len(gotDescriptors) != 1 {
-			t.Errorf("GetReference: expected to get %d descriptors, got %d", 1, len(gotDescriptors))
+			t.Errorf("ResolveReference: expected to get %d descriptors, got %d: %+v", 1, len(gotDescriptors), gotDescriptors)
 		}
 		gotDescriptor := gotDescriptors[0]
 
-		if !reflect.DeepEqual(test.descriptor, gotDescriptor) {
-			t.Errorf("GetReference: got different descriptor to original: expected=%v got=%v", test.descriptor, gotDescriptor)
+		if !reflect.DeepEqual(test.result, gotDescriptor) {
+			t.Errorf("ResolveReference: got different descriptor to original: expected=%v got=%v", test.result, gotDescriptor)
 		}
 
 		// Make sure that writing will FAIL.
-		if err := newEngineExt.UpdateReference(ctx, test.name+"new", test.descriptor); err == nil {
-			t.Errorf("PutReference: expected error on ro image!")
+		if err := newEngineExt.UpdateReference(ctx, name+"new", test.index); err == nil {
+			t.Errorf("UpdateReference: expected error on ro image!")
 		}
 
 		if err := newEngine.Close(); err != nil {

--- a/oci/casext/utils_dir_test.go
+++ b/oci/casext/utils_dir_test.go
@@ -1,0 +1,59 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016, 2017 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"os"
+	"syscall"
+	"testing"
+)
+
+// readonly makes the given path read-only (by bind-mounting it as "ro").
+// TODO: This should be done through an interface restriction in the test
+//       (which is then backed up by the readonly mount if necessary). The fact
+//       this test is necessary is a sign that we need a better split up of the
+//       CAS interface.
+// Copied from oci/cas/drivers/dir/dir_test.go.
+func readonly(t *testing.T, path string) {
+	if os.Geteuid() != 0 {
+		t.Log("readonly tests only work with root privileges")
+		t.Skip()
+	}
+
+	t.Logf("mounting %s as readonly", path)
+
+	if err := syscall.Mount(path, path, "", syscall.MS_BIND|syscall.MS_RDONLY, ""); err != nil {
+		t.Fatalf("mount %s as ro: %s", path, err)
+	}
+	if err := syscall.Mount("none", path, "", syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_RDONLY, ""); err != nil {
+		t.Fatalf("mount %s as ro: %s", path, err)
+	}
+}
+
+// readwrite undoes the effect of readonly.
+// Copied from oci/cas/drivers/dir/dir_test.go.
+func readwrite(t *testing.T, path string) {
+	if os.Geteuid() != 0 {
+		t.Log("readonly tests only work with root privileges")
+		t.Skip()
+	}
+
+	if err := syscall.Unmount(path, syscall.MNT_DETACH); err != nil {
+		t.Fatalf("unmount %s: %s", path, err)
+	}
+}

--- a/test/create.bats
+++ b/test/create.bats
@@ -44,7 +44,10 @@ function teardown() {
 	sane_run find "$NEWIMAGE/blobs" -type f
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
-	sane_run find "$NEWIMAGE/refs" -type f
+	# Note that this is _very_ dodgy at the moment because of how complicated
+	# the reference handling is now.
+	# XXX: Make sure to update this for 1.0.0-rc6 where the refname changed.
+	sane_run jq -SMr '.manifests[]? | .annotations["org.opencontainers.ref.name"] | strings' "$NEWIMAGE/index.json"
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
 
@@ -52,7 +55,7 @@ function teardown() {
 	[ -f "$NEWIMAGE/oci-layout" ]
 	[ -d "$NEWIMAGE/blobs" ]
 	[ -d "$NEWIMAGE/blobs/sha256" ]
-	[ -d "$NEWIMAGE/refs" ]
+	[ -f "$NEWIMAGE/index.json" ]
 
 	# Make sure that attempting to create a new image will fail.
 	umoci init --layout "$NEWIMAGE"

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -42,7 +42,10 @@ function teardown() {
 	image-verify "${IMAGE}"
 
 	# Check how many refs there actually are.
-	sane_run find "$IMAGE/refs" -type f
+	# Note that this is _very_ dodgy at the moment because of how complicated
+	# the reference handling is now.
+	# XXX: Make sure to update this for 1.0.0-rc6 where the refname changed.
+	sane_run jq -SMr '.manifests[] | .annotations["org.opencontainers.ref.name"] | strings' "$IMAGE/index.json"
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq "$nrefs" ]
 

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/descriptor.go
@@ -30,4 +30,7 @@ type Descriptor struct {
 
 	// URLs specifies a list of URLs from which this object MAY be downloaded
 	URLs []string `json:"urls,omitempty"`
+
+	// Annotations contains arbitrary metadata relating to the targeted content.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/image_index.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/image_index.go
@@ -50,14 +50,14 @@ type ManifestDescriptor struct {
 	Platform Platform `json:"platform"`
 }
 
-// ManifestList references manifests for various platforms.
-// This structure provides `application/vnd.oci.image.manifest.list.v1+json` mediatype when marshalled to JSON.
-type ManifestList struct {
+// ImageIndex references manifests for various platforms.
+// This structure provides `application/vnd.oci.image.index.v1+json` mediatype when marshalled to JSON.
+type ImageIndex struct {
 	specs.Versioned
 
 	// Manifests references platform specific manifests.
 	Manifests []ManifestDescriptor `json:"manifests"`
 
-	// Annotations contains arbitrary metadata for the manifest list.
+	// Annotations contains arbitrary metadata for the image index.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/layout.go
@@ -14,18 +14,15 @@
 
 package v1
 
-import "regexp"
-
-// ImageLayoutVersion is the version of ImageLayout
-const ImageLayoutVersion = "1.0.0"
+const (
+	// ImageLayoutFile is the file name of oci image layout file
+	ImageLayoutFile = "oci-layout"
+	// ImageLayoutVersion is the version of ImageLayout
+	ImageLayoutVersion = "1.0.0"
+)
 
 // ImageLayout is the structure in the "oci-layout" file, found in the root
 // of an OCI Image-layout directory.
 type ImageLayout struct {
 	Version string `json:"imageLayoutVersion"`
 }
-
-var (
-	// RefsRegexp matches requirement of image-layout 'refs' charset.
-	RefsRegexp = regexp.MustCompile(`^[a-zA-Z0-9-._]+$`)
-)

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/manifest.go
@@ -16,7 +16,7 @@ package v1
 
 import "github.com/opencontainers/image-spec/specs-go"
 
-// Manifest provides `application/vnd.oci.image.manifest.list.v1+json` mediatype structure when marshalled to JSON.
+// Manifest provides `application/vnd.oci.image.manifest.v1+json` mediatype structure when marshalled to JSON.
 type Manifest struct {
 	specs.Versioned
 
@@ -27,6 +27,6 @@ type Manifest struct {
 	// Layers is an indexed list of layers referenced by the manifest.
 	Layers []Descriptor `json:"layers"`
 
-	// Annotations contains arbitrary metadata for the manifest list.
+	// Annotations contains arbitrary metadata for the manifest.
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/v1/mediatype.go
@@ -21,8 +21,8 @@ const (
 	// MediaTypeImageManifest specifies the media type for an image manifest.
 	MediaTypeImageManifest = "application/vnd.oci.image.manifest.v1+json"
 
-	// MediaTypeImageManifestList specifies the media type for an image manifest list.
-	MediaTypeImageManifestList = "application/vnd.oci.image.manifest.list.v1+json"
+	// MediaTypeImageIndex specifies the media type for an image index.
+	MediaTypeImageIndex = "application/vnd.oci.image.index.v1+json"
 
 	// MediaTypeImageLayer is the media type used for layers referenced by the manifest.
 	MediaTypeImageLayer = "application/vnd.oci.image.layer.v1.tar"

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc4"
+	VersionDev = "-rc5"
 )
 
 // Version is the specification version that the package types support.


### PR DESCRIPTION
This is a fairly large semantic and library change because of the semantic
change of tags no longer being a first-class property of the underlying
storage. This required a change to `oci/cas` and adding reference resolution to
`oci/casext` (which is actually nicer on some level but conflicts are hard to
resolve now).

Currently platform filtering is not implemented, and the current handling of
ambiguous tags is not really ironed out (errors are returned). This is
something that will need to be ironed out in the future especially if we want
to support creating multi-level trees of `Index`es.

In addition, due to the way that our CI works we need to update to the latest
`skopeo` but we can't do this in the distribution because this change is still
being worked on. IMO it would be better if we first resolve #132 before merging
this so that we actually can test this in a more sane way going forward.

Signed-off-by: Aleksa Sarai <asarai@suse.de>