### PR TITLE
make: add validation for reproducibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ script:
   - chmod a+rwx . # Necessary to make Travis co-operate with Docker.
   - make umoci
   - make umoci.static
+  - make local-validate-reproducible
   - make DOCKER_IMAGE=$DOCKER_IMAGE ci

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ validate: umociimage
 
 EPOCH_COMMIT ?= 97ecdbd53dcb72b7a0d62196df281f131dc9eb2f
 .PHONY: local-validate
-local-validate:
+local-validate: local-validate-reproducible
 	test -z "$$(gofmt -s -l . | grep -v '^vendor/' | grep -v '^third_party/' | tee /dev/stderr)"
 	out="$$(golint $(PROJECT)/... | grep -v '/vendor/' | grep -v '/third_party/' | grep -vE 'system/utils_linux.*ALL_CAPS|system/mknod_linux.*underscores')"; \
 	if [ -n "$$out" ]; then \
@@ -89,6 +89,22 @@ local-validate:
 	go vet $(shell go list $(PROJECT)/... | grep -v /vendor/ | grep -v /third_party/)
 	#@echo "git-validation"
 	#@git-validation -v -run DCO,short-subject,dangling-whitespace $(EPOCH_COMMIT)..HEAD
+
+# Make sure that our builds are reproducible even if you wait between them and
+# the modified time of the files is different.
+.PHONY: local-validate-reproducible
+local-validate-reproducible:
+	@mkdir -p .tmp-validate
+	@echo " [MAKE-A] umoci"
+	@make -B umoci && cp umoci .tmp-validate/umoci.a
+	@echo " [WAIT]"
+	@sleep 10s && touch $(GO_SRC)
+	@echo " [MAKE-B] umoci"
+	@make -B umoci && cp umoci .tmp-validate/umoci.b
+	@echo "  [CMP] umoci"
+	@diff -s .tmp-validate/umoci.{a,b}
+	@sha256sum .tmp-validate/umoci.{a,b}
+	@rm -r .tmp-validate/umoci.{a,b}
 
 MANPAGES_MD := $(wildcard doc/man/*.md)
 MANPAGES    := $(MANPAGES_MD:%.md=%)

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,9 @@ VERSION := $(shell cat ./VERSION)
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
-DYN_BUILD_FLAGS := -ldflags "-s -w -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"
-STATIC_BUILD_FLAGS := -ldflags "-s -w -extldflags '-static' -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"
+BUILD_FLAGS ?=
+DYN_BUILD_FLAGS := $(BUILD_FLAGS) -buildmode=pie -ldflags "-s -w -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"
+STATIC_BUILD_FLAGS := $(BUILD_FLAGS) -ldflags "-s -w -extldflags '-static' -X main.gitCommit=${COMMIT} -X main.version=${VERSION}" -tags "$(BUILDTAGS)"
 
 .DEFAULT: umoci
 


### PR DESCRIPTION
Add a new target local-validate-reproducible which will verify that our
builds remain reproducible even if you rebuild them within 10s of each
other and the modified time of the source code is changed. This is a
very trivial way of checking reproducibility, but Go makes guarantees
that the binaries are always reproducible[1].

[1]: https://blog.filippo.io/reproducing-go-binaries-byte-by-byte/

Signed-off-by: Aleksa Sarai <asarai@suse.de>