### PR TITLE
*: update to v1.0.0 of {runtime,image}-spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   program][cii]. openSUSE/umoci#134
 - `umoci` also now has more extensive architecture, quick-start and roadmap
   documentation. openSUSE/umoci#134
-- `umoci` now supports [`1.0.0-rc7` of the OCI image
-  specification][ispec-v1.0.0-rc7] and [`1.0.0-rc6` of the OCI runtime
-  specification][rspec-v1.0.0-rc6], which are the last `1.0.0` release
-  candidates and will be functionaly identical to `1.0.0` when released. Note
+- `umoci` now supports [`1.0.0` of the OCI image
+  specification][ispec-v1.0.0] and [`1.0.0` of the OCI runtime
+  specification][rspec-v1.0.0], which are the first milestone release. Note
   that there are still some remaining UX issues with `--image` and other parts
   of `umoci` which may be subject to change in future versions. In particular,
   this update of the specification now means that images may have ambiguous
@@ -44,8 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   openSUSE/umoci#127
 
 [cii]: https://bestpractices.coreinfrastructure.org/projects/1084
-[rspec-v1.0.0-rc6]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0-rc6
-[ispec-v1.0.0-rc7]: https://github.com/opencontainers/image-spec/releases/tag/v1.0.0-rc7
+[rspec-v1.0.0]: https://github.com/opencontainers/runtime-spec/releases/tag/v1.0.0
+[ispec-v1.0.0]: https://github.com/opencontainers/image-spec/releases/tag/v1.0.0
 [ispec-pr492]: https://github.com/opencontainers/image-spec/pull/492
 [ispec-pr694]: https://github.com/opencontainers/image-spec/pull/694
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,9 +76,10 @@ RUN mkdir -p /go/src/$IMAGETOOLS_PROJECT && \
 
 # Reinstall oci-runtime-tools from source to avoid having to package new versions
 # in openSUSE while testing PRs.
-ENV RUNTIMETOOLS_VERSION=2ed047ae6bddbd90bbfe24b2cb4c648175229bd4 RUNTIMETOOLS_PROJECT=github.com/opencontainers/runtime-tools
+# XXX: Switch back to upstream runtime-tools once https://github.com/opencontainers/runtime-tools/pull/432 is merged.
+ENV RUNTIMETOOLS_VERSION=c18317bd9b103c5454c2bd2b61cf6d3484e836bf RUNTIMETOOLS_PROJECT=github.com/opencontainers/runtime-tools
 RUN mkdir -p /go/src/$RUNTIMETOOLS_PROJECT && \
-	git clone https://$RUNTIMETOOLS_PROJECT /go/src/$RUNTIMETOOLS_PROJECT && \
+	git clone https://github.com/cyphar/runtime-tools /go/src/$RUNTIMETOOLS_PROJECT && \
 	( cd /go/src/$RUNTIMETOOLS_PROJECT ; git checkout $RUNTIMETOOLS_VERSION ; ) && \
 	make -C /go/src/$RUNTIMETOOLS_PROJECT tool && \
 	install -m0755 /go/src/$RUNTIMETOOLS_PROJECT/oci-runtime-tool /usr/bin/oci-runtime-tool && \

--- a/hack/patch.sh
+++ b/hack/patch.sh
@@ -34,3 +34,5 @@ patch github.com/pkg/errors errors-0001-errors-add-Debug-function.patch
 
 # Backport https://github.com/opencontainers/runtime-tools/pull/359.
 patch github.com/opencontainers/runtime-tools runtime-tools-0001-generate-remove-validate-dependency.patch
+# Fixes the v1.0.0 build.
+patch github.com/opencontainers/runtime-tools runtime-tools-0002-generate-fix-build-for-v1.0.0.patch

--- a/hack/runtime-tools-0002-generate-fix-build-for-v1.0.0.patch
+++ b/hack/runtime-tools-0002-generate-fix-build-for-v1.0.0.patch
@@ -1,0 +1,32 @@
+From abccaf9555f6a49f9a3ddf0db81e813649a0ec09 Mon Sep 17 00:00:00 2001
+From: Aleksa Sarai <asarai@suse.de>
+Date: Thu, 20 Jul 2017 03:33:37 +1000
+Subject: [PATCH] generate: fix build for v1.0.0
+
+There was a very late post-v1.0.0-rc6 hotfix that broke the build
+between the two versions. It's not a semantic change, a field was moved
+to a sub-struct.
+
+Signed-off-by: Aleksa Sarai <asarai@suse.de>
+---
+ generate/generate.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/generate/generate.go b/generate/generate.go
+index 0eeda5c776bd..848a970824dd 100644
+--- a/generate/generate.go
++++ b/generate/generate.go
+@@ -486,8 +486,8 @@ func (g *Generator) SetLinuxMountLabel(label string) {
+ 
+ // SetLinuxResourcesDisableOOMKiller sets g.spec.Linux.Resources.DisableOOMKiller.
+ func (g *Generator) SetLinuxResourcesDisableOOMKiller(disable bool) {
+-	g.initSpecLinuxResources()
+-	g.spec.Linux.Resources.DisableOOMKiller = &disable
++	g.initSpecLinuxResourcesMemory()
++	g.spec.Linux.Resources.Memory.DisableOOMKiller = &disable
+ }
+ 
+ // SetProcessOOMScoreAdj sets g.spec.Process.OOMScoreAdj.
+-- 
+2.13.2
+

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -120,8 +120,8 @@ clone() {
 # TODO: Put this in a vendor.conf file or something like that (to be compatible
 #       with LK4D4/vndr). This setup is a bit unwieldy.
 clone github.com/opencontainers/go-digest v1.0.0-rc0
-clone github.com/opencontainers/image-spec v1.0.0-rc7
-clone github.com/opencontainers/runtime-spec v1.0.0-rc6
+clone github.com/opencontainers/image-spec v1.0.0
+clone github.com/opencontainers/runtime-spec v1.0.0
 clone github.com/opencontainers/runtime-tools 2ed047ae6bddbd90bbfe24b2cb4c648175229bd4
 clone github.com/syndtr/gocapability 2c00daeb6c3b45114c80ac44119e7b8801fdd852
 clone golang.org/x/crypto b8a2a83acfe6e6770b75de42d5ff4c67596675c0 https://github.com/golang/crypto

--- a/vendor/github.com/opencontainers/image-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/image-spec/specs-go/version.go
@@ -25,7 +25,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc7"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -284,6 +284,8 @@ type LinuxMemory struct {
 	KernelTCP *int64 `json:"kernelTCP,omitempty"`
 	// How aggressive the kernel will swap memory pages.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 }
 
 // LinuxCPU for Linux cgroup 'cpu' resource management
@@ -322,8 +324,6 @@ type LinuxNetwork struct {
 type LinuxResources struct {
 	// Devices configures the device whitelist.
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
-	// DisableOOMKiller disables the OOM killer for out of memory conditions
-	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration
@@ -550,7 +550,7 @@ const (
 type LinuxSeccompArg struct {
 	Index    uint                 `json:"index"`
 	Value    uint64               `json:"value"`
-	ValueTwo uint64               `json:"valueTwo,omiempty"`
+	ValueTwo uint64               `json:"valueTwo,omitempty"`
 	Op       LinuxSeccompOperator `json:"op"`
 }
 

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -9,7 +9,7 @@ type State struct {
 	// Status is the runtime status of the container.
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
-	Pid int `json:"pid"`
+	Pid int `json:"pid,omitempty"`
 	// Bundle is the path to the container's bundle directory.
 	Bundle string `json:"bundle"`
 	// Annotations are key values associated with the container.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc6"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
+++ b/vendor/github.com/opencontainers/runtime-tools/generate/generate.go
@@ -485,8 +485,8 @@ func (g *Generator) SetLinuxMountLabel(label string) {
 
 // SetLinuxResourcesDisableOOMKiller sets g.spec.Linux.Resources.DisableOOMKiller.
 func (g *Generator) SetLinuxResourcesDisableOOMKiller(disable bool) {
-	g.initSpecLinuxResources()
-	g.spec.Linux.Resources.DisableOOMKiller = &disable
+	g.initSpecLinuxResourcesMemory()
+	g.spec.Linux.Resources.Memory.DisableOOMKiller = &disable
 }
 
 // SetProcessOOMScoreAdj sets g.spec.Process.OOMScoreAdj.


### PR DESCRIPTION
On paper this change should not affect anything, but we needed to add a
patch in order to fix a late change in runtime-spec that broke the
runtime-tools/generate build.

Signed-off-by: Aleksa Sarai <asarai@suse.de>