### PR TITLE
oci: consume any excess data present in layer archives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `umoci`. openSUSE/umoci#166 openSUSE/umoci#169
 - Updated to [v0.4.0 of `go-mtree`][gomtree-v0.4.0], which fixes several minor
   bugs with manifest generation. openSUSE/umoci#176
+- `umoci unpack` would not handle "weird" tar archive layers previously (it
+  would error out with DiffID errors). While this wouldn't cause issues for
+  layers generated using Go's `archive/tar` implementation, it would cause
+  issues for GNU gzip and other such tools.
 
 ### Changed
 - `umoci unpack`'s mapping options (`--uid-map` and `--gid-map`) have had an


### PR DESCRIPTION
Different tar implementations can have different levels of redundant
padding and other similar weird behaviours. While on paper they are all
entirely valid archives, Go's tar.Reader implementation doesn't
guarantee that the entire stream will be consumed (which can result in
the later diff_id check failing because the digester didn't get the
whole uncompressed stream). Just blindly consume anything left in the
layer.

Reported-by: "Serge E. Hallyn" <serge@hallyn.com>
Signed-off-by: Aleksa Sarai <asarai@suse.de>