### PR TITLE
umoci: add {bash,zsh} autocompletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /vendor/pkg
 /vendor/github.com/openSUSE/umoci
 /umoci.cov*
+/autocomplete/*-gen

--- a/Makefile
+++ b/Makefile
@@ -62,12 +62,24 @@ umoci.cover: $(GO_SRC)
 release:
 	hack/release.sh -S "$(GPG_KEYID)" -r release/$(VERSION) -v $(VERSION)
 
+.PHONY: generate-completion
+generate-completion: $(GO_SRC)
+	$(GO) build ${DYN_BUILD_FLAGS} -ldflags "-X main.bashCompletion=true" -o $(BUILD_DIR)/umoci-gen ${CMD}
+	$(BUILD_DIR)/umoci-gen --generate-bash-completion > autocomplete/umoci_commands.txt
+	sed -e "3r autocomplete/umoci_commands.txt" autocomplete/bash_autocomplete > autocomplete/bash_autocomplete-gen
+	rm $(BUILD_DIR)/umoci-gen
+
+.PHONY: install-completion
+install-completion: generate-completion
+	cp -v autocomplete/bash_autocomplete-gen /etc/zsh_completion.d/_umoci
+	cp -v autocomplete/zsh_autocomplete /etc/zsh_completion.d/_umoci
+
 .PHONY: install
-install: $(GO_SRC)
+install: $(GO_SRC) install-completion
 	$(GO) install -v ${DYN_BUILD_FLAGS} ${CMD}
 
 .PHONY: install.static
-install.static: $(GO_SRC)
+install.static: $(GO_SRC) install-completion
 	$(GO) install -v ${STATIC_BUILD_FLAGS} ${CMD}
 
 .PHONY: update-deps

--- a/autocomplete/bash_autocomplete
+++ b/autocomplete/bash_autocomplete
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+UMOCI_CMDS="
+"
+
+_umoci() {
+    local cur
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    COMPREPLY=( $(compgen -W "${UMOCI_CMDS}" -- ${cur}) )
+    return 0
+}
+
+complete -F _umoci umoci

--- a/autocomplete/umoci_commands.txt
+++ b/autocomplete/umoci_commands.txt
@@ -1,0 +1,15 @@
+config
+unpack
+repack
+gc
+init
+new
+tag
+remove
+rm
+list
+ls
+stat
+raw
+help
+h

--- a/autocomplete/zsh_autocomplete
+++ b/autocomplete/zsh_autocomplete
@@ -1,0 +1,6 @@
+#compdef _umoci umoci
+
+autoload -U compinit && compinit
+autoload -U bashcompinit && bashcompinit
+
+source /etc/bash_completion.d/umoci

--- a/cmd/umoci/main.go
+++ b/cmd/umoci/main.go
@@ -43,6 +43,10 @@ const (
 	categoryImage  = "image"
 )
 
+// bashCompletion is used to generate a list of commands for the bash and zsh
+// autocompletion scripts.
+var bashCompletion = "false"
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "umoci"
@@ -52,6 +56,10 @@ func main() {
 			Name:  "Aleksa Sarai",
 			Email: "asarai@suse.com",
 		},
+	}
+
+	if bashCompletion == "true" {
+		app.EnableBashCompletion = true
 	}
 
 	// Fill the version.

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2016, 2017 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+@test "umoci autocompletion" {
+	run cat autocomplete/umoci_commands.txt
+	[ "$status" -eq 0 ]
+	[ "${lines[0]}" = "config" ]
+	[ "${lines[1]}" = "unpack" ]
+	[ "${lines[2]}" = "repack" ]
+	[ "${lines[3]}" = "gc" ]
+	[ "${lines[4]}" = "init" ]
+	[ "${lines[5]}" = "new" ]
+	[ "${lines[6]}" = "tag" ]
+	[ "${lines[7]}" = "remove" ]
+	[ "${lines[8]}" = "rm" ]
+	[ "${lines[9]}" = "list" ]
+	[ "${lines[10]}" = "ls" ]
+	[ "${lines[11]}" = "stat" ]
+	[ "${lines[12]}" = "raw" ]
+	[ "${lines[13]}" = "help" ]
+	[ "${lines[14]}" = "h" ]
+}


### PR DESCRIPTION
urfave/cli supports autocompletion for commands and subcommands. The
magic behind is adding a hidden --generate-bash-completion flag to the
program to generate a list of commands.  The generated list is then
added to the bash-completion script.  Note well, that urfave/cli
currently doesn't support autocompletion for flags.

Signed-off-by: Valentin Rothberg <vrothberg@suse.com>
Fixes: #139