### PR TITLE
*: add ability to use a shared CAS directory

### DIFF
--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -123,6 +123,7 @@ func parseKV(input string) (string, string, error) {
 func config(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	fromName := ctx.App.Metadata["--image-tag"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// By default we clobber the old tag.
 	tagName := fromName
@@ -131,7 +132,7 @@ func config(ctx *cli.Context) error {
 	}
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/gc.go
+++ b/cmd/umoci/gc.go
@@ -51,9 +51,10 @@ root set of references. All other blobs will be removed.`,
 
 func gc(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/gc.go
+++ b/cmd/umoci/gc.go
@@ -51,10 +51,12 @@ root set of references. All other blobs will be removed.`,
 
 func gc(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
-	sharedCasPath := ctx.String("shared-cas")
+	if ctx.String("shared-cas") != "" {
+		return errors.New("gc not supported with --shared-cas")
+	}
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath, sharedCasPath)
+	engine, err := dir.Open(imagePath, "")
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/new.go
+++ b/cmd/umoci/new.go
@@ -54,9 +54,10 @@ needing a base image to start from.`,
 func newImage(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	tagName := ctx.App.Metadata["--image-tag"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/raw-runtime-config.go
+++ b/cmd/umoci/raw-runtime-config.go
@@ -87,6 +87,7 @@ func rawConfig(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	fromName := ctx.App.Metadata["--image-tag"].(string)
 	configPath := ctx.App.Metadata["config"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	var meta UmociMeta
 	meta.Version = UmociMetaVersion
@@ -124,7 +125,7 @@ func rawConfig(ctx *cli.Context) error {
 	}).Debugf("parsed mappings")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -99,6 +99,7 @@ func repack(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	tagName := ctx.App.Metadata["--image-tag"].(string)
 	bundlePath := ctx.App.Metadata["bundle"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Read the metadata first.
 	meta, err := ReadBundleMeta(bundlePath)
@@ -117,7 +118,7 @@ func repack(ctx *cli.Context) error {
 	}
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/stat.go
+++ b/cmd/umoci/stat.go
@@ -58,9 +58,10 @@ humans to read, and might change in future versions.`,
 func stat(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	tagName := ctx.App.Metadata["--image-tag"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/tag.go
+++ b/cmd/umoci/tag.go
@@ -60,9 +60,10 @@ func tagAdd(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	fromName := ctx.App.Metadata["--image-tag"].(string)
 	tagName := ctx.App.Metadata["new-tag"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}
@@ -111,9 +112,10 @@ tag to remove.`,
 func tagRemove(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	tagName := ctx.App.Metadata["--image-tag"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}
@@ -148,9 +150,10 @@ line. See umoci-stat(1) to get more information about each tagged image.`,
 
 func tagList(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -83,6 +83,7 @@ func unpack(ctx *cli.Context) error {
 	imagePath := ctx.App.Metadata["--image-path"].(string)
 	fromName := ctx.App.Metadata["--image-tag"].(string)
 	bundlePath := ctx.App.Metadata["bundle"].(string)
+	sharedCasPath := ctx.String("shared-cas")
 
 	var meta UmociMeta
 	meta.Version = UmociMetaVersion
@@ -120,7 +121,7 @@ func unpack(ctx *cli.Context) error {
 	}).Debugf("parsed mappings")
 
 	// Get a reference to the CAS.
-	engine, err := dir.Open(imagePath)
+	engine, err := dir.Open(imagePath, sharedCasPath)
 	if err != nil {
 		return errors.Wrap(err, "open CAS")
 	}

--- a/cmd/umoci/utils_ux.go
+++ b/cmd/umoci/utils_ux.go
@@ -130,10 +130,17 @@ func uxTag(cmd cli.Command) cli.Command {
 // tag) will be stored in ctx.Metadata["--image-path"] and
 // ctx.Metadata["--image-tag"] as strings (both will be nil if --image is not
 // specified).
+// A --shared-cas flag is also added to the given cli.Command, which allows
+// users to provide a different directory to be used for blob operations
 func uxImage(cmd cli.Command) cli.Command {
 	cmd.Flags = append(cmd.Flags, cli.StringFlag{
 		Name:  "image",
 		Usage: "OCI image URI of the form 'path[:tag]'",
+	})
+
+	cmd.Flags = append(cmd.Flags, cli.StringFlag{
+		Name:  "shared-cas",
+		Usage: "shared directory to use for blobs (instead of internal image layout directory)",
 	})
 
 	oldBefore := cmd.Before
@@ -181,13 +188,20 @@ func uxImage(cmd cli.Command) cli.Command {
 	return cmd
 }
 
-// uxLayout adds an --layout flag to the given cli.Command as well as adding
+// uxLayout adds a --layout flag to the given cli.Command as well as adding
 // relevant validation logic to the .Before of the command. The value is stored
 // in ctx.App.Metadata["--image-path"] as a string (or nil --layout was not set).
+// A --shared-cas flag is also added to the given cli.Command, which allows
+// users to provide a different directory to be used for blob operations
 func uxLayout(cmd cli.Command) cli.Command {
 	cmd.Flags = append(cmd.Flags, cli.StringFlag{
 		Name:  "layout",
 		Usage: "path to an OCI image layout",
+	})
+
+	cmd.Flags = append(cmd.Flags, cli.StringFlag{
+		Name:  "shared-cas",
+		Usage: "shared directory to use for blobs (instead of internal image layout directory)",
 	})
 
 	oldBefore := cmd.Before

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -223,7 +223,7 @@ func (m *Mutator) add(ctx context.Context, reader io.Reader) (digest.Digest, int
 		return "", -1, errors.Wrap(err, "getting cache failed")
 	}
 
-	diffidDigester := cas.BlobAlgorithm.Digester()
+	diffidDigester := cas.DefaultBlobAlgorithm.Digester()
 	hashReader := io.TeeReader(reader, diffidDigester.Hash())
 
 	pipeReader, pipeWriter := io.Pipe()

--- a/mutate/mutate_test.go
+++ b/mutate/mutate_test.go
@@ -46,12 +46,12 @@ const (
 )
 
 func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
-	dir = filepath.Join(dir, "image")
-	if err := casdir.Create(dir); err != nil {
+	image := filepath.Join(dir, "image")
+	if err := casdir.Create(image); err != nil {
 		t.Fatal(err)
 	}
 
-	engine, err := casdir.Open(dir)
+	engine, err := casdir.Open(image, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func setup(t *testing.T, dir string) (cas.Engine, ispec.Descriptor) {
 	tw.Close()
 
 	// Push the base layer.
-	diffidDigester := cas.BlobAlgorithm.Digester()
+	diffidDigester := cas.DefaultBlobAlgorithm.Digester()
 	hashReader := io.TeeReader(&buffer, diffidDigester.Hash())
 	layerDigest, layerSize, err := engine.PutBlob(context.Background(), hashReader)
 	if err != nil {

--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -32,13 +32,18 @@ import (
 )
 
 const (
-	// BlobAlgorithm is the name of the only supported digest algorithm for blobs.
-	// FIXME: We can make this a list.
-	BlobAlgorithm = digest.SHA256
+	// DefaultBlobAlgorithm is the default supported digest algorithm for blobs
+	DefaultBlobAlgorithm = digest.SHA256
 )
 
-// Exposed errors.
 var (
+	// BlobAlgorithms contains the supported digest algorithms for blobs
+	BlobAlgorithms = []digest.Algorithm{
+		digest.SHA256,
+	}
+
+	// Exposed errors
+
 	// ErrNotExist is effectively an implementation-neutral version of
 	// os.ErrNotExist.
 	ErrNotExist = fmt.Errorf("no such blob or index")

--- a/oci/cas/dir/cas_test.go
+++ b/oci/cas/dir/cas_test.go
@@ -47,7 +47,7 @@ func TestCreateLayout(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	engine, err := Open(image)
+	engine, err := Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -85,7 +85,7 @@ func TestEngineBlob(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	engine, err := Open(image)
+	engine, err := Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -98,7 +98,7 @@ func TestEngineBlob(t *testing.T) {
 		{[]byte("some blob")},
 		{[]byte("another blob")},
 	} {
-		digester := cas.BlobAlgorithm.Digester()
+		digester := cas.DefaultBlobAlgorithm.Digester()
 		if _, err := io.Copy(digester.Hash(), bytes.NewReader(test.bytes)); err != nil {
 			t.Fatalf("could not hash bytes: %+v", err)
 		}
@@ -172,7 +172,7 @@ func TestEngineValidate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -186,7 +186,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(image, layoutFile), []byte("invalid JSON"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -200,7 +200,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(image, layoutFile), []byte("{}"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -220,7 +220,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(image, blobDirectory)); err != nil {
 		t.Fatalf("unexpected error deleting blobdir: %+v", err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -243,7 +243,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(image, blobDirectory), []byte(""), 0755); err != nil {
 		t.Fatal(err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -263,7 +263,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := os.RemoveAll(filepath.Join(image, indexFile)); err != nil {
 		t.Fatalf("unexpected error deleting index: %+v", err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -286,7 +286,7 @@ func TestEngineValidate(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(image, indexFile), 0755); err != nil {
 		t.Fatal(err)
 	}
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()
@@ -294,7 +294,7 @@ func TestEngineValidate(t *testing.T) {
 
 	// No such directory.
 	image = filepath.Join(root, "non-exist")
-	engine, err = Open(image)
+	engine, err = Open(image, "")
 	if err == nil {
 		t.Errorf("expected to get an error")
 		engine.Close()

--- a/oci/cas/dir/dir_test.go
+++ b/oci/cas/dir/dir_test.go
@@ -85,7 +85,7 @@ func TestCreateLayoutReadonly(t *testing.T) {
 	readonly(t, image)
 	defer readwrite(t, image)
 
-	engine, err := Open(image)
+	engine, err := Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -125,12 +125,12 @@ func TestEngineBlobReadonly(t *testing.T) {
 		{[]byte("some blob")},
 		{[]byte("another blob")},
 	} {
-		engine, err := Open(image)
+		engine, err := Open(image, "")
 		if err != nil {
 			t.Fatalf("unexpected error opening image: %+v", err)
 		}
 
-		digester := cas.BlobAlgorithm.Digester()
+		digester := cas.DefaultBlobAlgorithm.Digester()
 		if _, err := io.Copy(digester.Hash(), bytes.NewReader(test.bytes)); err != nil {
 			t.Fatalf("could not hash bytes: %+v", err)
 		}
@@ -155,7 +155,7 @@ func TestEngineBlobReadonly(t *testing.T) {
 		// make it readonly
 		readonly(t, image)
 
-		newEngine, err := Open(image)
+		newEngine, err := Open(image, "")
 		if err != nil {
 			t.Errorf("unexpected error opening ro image: %+v", err)
 		}
@@ -209,12 +209,12 @@ func TestEngineGCLocking(t *testing.T) {
 	content := []byte("here's some sample content")
 
 	// Open a reference to the CAS, and make sure that it has a .temp set up.
-	engine, err := Open(image)
+	engine, err := Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
 
-	digester := cas.BlobAlgorithm.Digester()
+	digester := cas.DefaultBlobAlgorithm.Digester()
 	if _, err := io.Copy(digester.Hash(), bytes.NewReader(content)); err != nil {
 		t.Fatalf("could not hash bytes: %+v", err)
 	}
@@ -248,7 +248,7 @@ func TestEngineGCLocking(t *testing.T) {
 	}
 
 	// Open a new reference and GC it.
-	gcEngine, err := Open(image)
+	gcEngine, err := Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}

--- a/oci/casext/json_dir_test.go
+++ b/oci/casext/json_dir_test.go
@@ -44,7 +44,7 @@ func TestEngineBlobJSON(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	engine, err := dir.Open(image)
+	engine, err := dir.Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -140,7 +140,7 @@ func TestEngineBlobJSONReadonly(t *testing.T) {
 		{object{"a value", 100}},
 		{object{"another value", 200}},
 	} {
-		engine, err := dir.Open(image)
+		engine, err := dir.Open(image, "")
 		if err != nil {
 			t.Fatalf("unexpected error opening image: %+v", err)
 		}
@@ -158,7 +158,7 @@ func TestEngineBlobJSONReadonly(t *testing.T) {
 		// make it readonly
 		readonly(t, image)
 
-		newEngine, err := dir.Open(image)
+		newEngine, err := dir.Open(image, "")
 		if err != nil {
 			t.Errorf("unexpected error opening ro image: %+v", err)
 		}

--- a/oci/casext/refname_dir_test.go
+++ b/oci/casext/refname_dir_test.go
@@ -250,7 +250,7 @@ func TestEngineReference(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	engine, err := dir.Open(image)
+	engine, err := dir.Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -314,7 +314,7 @@ func TestEngineReferenceReadonly(t *testing.T) {
 		t.Fatalf("unexpected error creating image: %+v", err)
 	}
 
-	engine, err := dir.Open(image)
+	engine, err := dir.Open(image, "")
 	if err != nil {
 		t.Fatalf("unexpected error opening image: %+v", err)
 	}
@@ -332,7 +332,7 @@ func TestEngineReferenceReadonly(t *testing.T) {
 	for idx, test := range descMap {
 		name := fmt.Sprintf("new_tag_%d", idx)
 
-		engine, err := dir.Open(image)
+		engine, err := dir.Open(image, "")
 		if err != nil {
 			t.Fatalf("unexpected error opening image: %+v", err)
 		}
@@ -349,7 +349,7 @@ func TestEngineReferenceReadonly(t *testing.T) {
 		// make it readonly
 		readonly(t, image)
 
-		newEngine, err := dir.Open(image)
+		newEngine, err := dir.Open(image, "")
 		if err != nil {
 			t.Errorf("unexpected error opening ro image: %+v", err)
 		}

--- a/oci/layer/unpack_test.go
+++ b/oci/layer/unpack_test.go
@@ -91,7 +91,7 @@ yRAbACGEEEIIIYQQQgghhBBCCKEr+wTE0sQyACgAAA==`,
 	if err := dir.Create(image); err != nil {
 		t.Fatal(err)
 	}
-	engine, err := dir.Open(image)
+	engine, err := dir.Open(image, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
umoci currently always expects blobs to live within the image layout
it's working on, in the aptly-named "blobs" subdirectory. However, the
OCI specification [1][1] permits this directory to be empty and for
implementations to look in other locations for referenced blobs.
This is particularly useful when working with multiple image layouts and
wanting to share blobs between them.

This patch adds a `--shared-cas` flag to all umoci commands that work
with image layouts. The flag expects a directory to be passed, and if
set, this directory will be used for all blob operations.

In the first implementation, we extend the `dirEngine` implementation of
the CAS interface to accept another (optional) `sharedCasPath` field.
Analogously to the CLI flag, if this field is supplied, it will be used
internally by the dirEngine for all blob-related operations.

[1]: https://github.com/opencontainers/image-spec/blob/7c889fafd04a893f5c5f50b7ab9963d5d64e5242/image-layout.md#blobs

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>