### PR TITLE
unpack: detect nonexistent tag [trivial]

### DIFF
--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -133,6 +133,9 @@ func unpack(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(fromDescriptorPaths) == 0 {
+		return errors.Errorf("tag is not found: %s", fromName)
+	}
 	if len(fromDescriptorPaths) != 1 {
 		// TODO: Handle this more nicely.
 		return errors.Errorf("tag is ambiguous: %s", fromName)


### PR DESCRIPTION
previously, nonexistent tags were confusingly reported as being
ambiguous.

Signed-off-by: Serge Hallyn <serge@hallyn.com>