### PR TITLE
detect nonexistent tag

### DIFF
--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -142,6 +142,9 @@ func config(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(fromDescriptorPaths) == 0 {
+		return errors.Errorf("tag not found: %s", fromName)
+	}
 	if len(fromDescriptorPaths) != 1 {
 		// TODO: Handle this more nicely.
 		return errors.Errorf("tag is ambiguous: %s", fromName)

--- a/cmd/umoci/raw-runtime-config.go
+++ b/cmd/umoci/raw-runtime-config.go
@@ -135,6 +135,9 @@ func rawConfig(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(fromDescriptorPaths) == 0 {
+		return errors.Errorf("tag not found: %s", fromName)
+	}
 	if len(fromDescriptorPaths) != 1 {
 		// TODO: Handle this more nicely.
 		return errors.Errorf("tag is ambiguous: %s", fromName)

--- a/cmd/umoci/stat.go
+++ b/cmd/umoci/stat.go
@@ -71,6 +71,9 @@ func stat(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(manifestDescriptorPaths) == 0 {
+		return errors.Errorf("tag not found: %s", tagName)
+	}
 	if len(manifestDescriptorPaths) != 1 {
 		// TODO: Handle this more nicely.
 		return errors.Errorf("tag is ambiguous: %s", tagName)

--- a/cmd/umoci/tag.go
+++ b/cmd/umoci/tag.go
@@ -74,6 +74,9 @@ func tagAdd(ctx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get descriptor")
 	}
+	if len(descriptorPaths) == 0 {
+		return errors.Errorf("tag not found: %s", fromName)
+	}
 	if len(descriptorPaths) != 1 {
 		// TODO: Handle this more nicely.
 		return errors.Errorf("tag is ambiguous: %s", fromName)

--- a/oci/casext/gc.go
+++ b/oci/casext/gc.go
@@ -50,6 +50,9 @@ func (e Engine) GC(ctx context.Context) error {
 		if err != nil {
 			return errors.Wrapf(err, "get root %s", name)
 		}
+		if len(descriptorPaths) == 0 {
+			return errors.Errorf("tag not found: %s", name)
+		}
 		if len(descriptorPaths) != 1 {
 			// TODO: Handle this more nicely.
 			return errors.Errorf("tag is ambiguous: %s", name)


### PR DESCRIPTION
Previously, nonexistent tags were confusingly reported as being
ambiguous.

Commit 09c6ab38 only handled one instance, catch the rest.

Signed-off-by: Serge Hallyn <serge@hallyn.com>