### PR TITLE
oci/cas/cas/dir: Drop supported-algorithm check in blobPath

### DIFF
--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -63,10 +63,6 @@ func blobPath(digest digest.Digest) (string, error) {
 	algo := digest.Algorithm()
 	hash := digest.Hex()
 
-	if algo != cas.BlobAlgorithm {
-		return "", errors.Errorf("unsupported algorithm: %q", algo)
-	}
-
 	return filepath.Join(blobDirectory, algo.String(), hash), nil
 }
 


### PR DESCRIPTION
~~I don't see a point to having a local preference distinct from the go-digest maintainer's suggestion.~~

I've dropped the supported check in dir's `blobPath`, because:

* `PutBlob` is calling `Digester` before it calls `blobPath`, and `Digester` will have already panicked on an unavailable algorithm.
* `GetBlob` will no longer error on usupported algorithms, but it should be up to the `GetBlob` consumer performing the validation to decide if the algorithm is supported or not.  I don't see why dir needs to have an opinion on this.
* `DeleteBlob` will no longer error on unsupported algorithms.  But if the caller asked us to delete a blob, I think we should delete it regardless of whether we can hash the blob contents.

Spun off from [here][1].

[1]: https://github.com/openSUSE/umoci/pull/190/files#r145502392