### PR TITLE
oci/cas/dir: Only Clean .umoci-* directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   responsibility of the caller (which was quite difficult if you were
   unprivileged). This is a breaking change, but is in the error path so it's
   not critical. openSUSE/umoci#174 openSUSE/umoci#187
+- `umoci gc` now will no longer remove unknown files and directories that
+  aren't `flock(2)`ed, thus ensuring that any possible OCI image-spec
+  extensions or other users of an image being operated on will no longer
+  break.  openSUSE/umoci#198
 
 ### Added
 - `umoci repack` now supports `--refresh-bundle` which will update the


### PR DESCRIPTION
Following Git and [defaulting to two weeks][1], as discussed in #17.  This allows the use of other non-flocking consumers (e.g. other CAS implementations) in the same base directory.

The added robustness comes with a price, though, since we now have to balance cleanliness vs. robustness for those other consumers.

* The hard-coded two-week cutoff may be insufficient for some use cases.  Maybe somebody will need to download a huge layer through a very slow pipe, and they'll bump into this limit.  Or maybe they have a high-cruft workflow or a small disk and would like to shorten this limit.  If that happens or we become concerned that it might, we should make `pruneExpire` configurable.

* Increasing `pruneExpire` protects more flock-less consumers from `Clean`, but also means that cruft can survive for longer before `Clean` is confident enough to remove it.  Setting an infite `pruneExpire` would be very safe but would make `Clean` a no-op.  Two weeks seems like a safe choice, since well-behaved consumers will clean up after themselves when they are closed.  `Clean` is just handling poorly-behaved consumers (or well-behaved consumers that had a hard shutdown).  I don't expect cruft to build up quickly enough for the two-week default to be an issue for most users.

Consumers who do not wish to rely on `pruneExpire` (perhaps they have long-running operations or are locally setting `pruneExpire` very short) can continue to flock their temporary files and directories to protect them from `Clean`.  Flocking a directory will also protect all content within that directory.

Removal errors (because of insufficient permissions, etc.) seemed like they should be non-fatal so we could continue to remove other cruft.  However, I didn't want to silently ignore the failed removal.  In this commit, I log those errors with a "warning" level.

The order of walk means that an old directory containing an old file will not be removed in a single pass.  The first `Clean` will fail to remove the old directory because it is not empty, but will remove the  old file (assuming it has sufficient permissions, etc.).  A second `Clean` pass will remove the now-empty old directory.  With cruft building slowly and `Clean` running fairly frequently, the delayed old-directory removal didn't seem like a big enough issue to warrant an immediate re-clean attempt.

[1]: https://git-scm.com/docs/git-gc