### PR TITLE
umoci/repack: add `--refresh-bundle` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   unprivileged). This is a breaking change, but is in the error path so it's
   not critical. openSUSE/umoci#174 openSUSE/umoci#187
 
+### Added
+- `umoci repack` now supports `--refresh-bundle` which will update the
+  OCI bundle's metadata (mtree and umoci-specific manifests) after packing the
+  image tag. This means that the bundle can be used as a base layer for
+  future diffs without needing to unpack the image again. openSUSE/umoci#196
+
 ## [0.3.1] - 2017-10-04
 ### Fixed
 - Fix several minor bugs in `hack/release.sh` that caused the release artefacts

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -130,7 +130,7 @@ func repack(ctx *cli.Context) error {
 		return errors.Wrap(err, "create mutator for base image")
 	}
 
-	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), "sha256:", "sha256_", 1)
+	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), ":", "_", 1)
 	mtreePath := filepath.Join(bundlePath, mtreeName+".mtree")
 	fullRootfsPath := filepath.Join(bundlePath, layer.RootfsName)
 
@@ -242,7 +242,7 @@ func repack(ctx *cli.Context) error {
 	log.Infof("created new tag for image manifest: %s", tagName)
 
 	if ctx.Bool("refresh-bundle") {
-		newMtreeName := strings.Replace(newDescriptorPath.Descriptor().Digest.String(), "sha256:", "sha256_", 1)
+		newMtreeName := strings.Replace(newDescriptorPath.Descriptor().Digest.String(), ":", "_", 1)
 		if err := generateBundleManifest(newMtreeName, bundlePath, fsEval); err != nil {
 			return errors.Wrap(err, "write mtree metadata")
 		}

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -243,7 +243,7 @@ func repack(ctx *cli.Context) error {
 
 	if ctx.Bool("refresh-bundle") {
 		newMtreeName := strings.Replace(newDescriptorPath.Descriptor().Digest.String(), "sha256:", "sha256_", 1)
-		if err := writeMtree(newMtreeName, bundlePath, fsEval); err != nil {
+		if err := generateBundleManifest(newMtreeName, bundlePath, fsEval); err != nil {
 			return errors.Wrap(err, "write mtree metadata")
 		}
 		if err := os.Remove(mtreePath); err != nil {

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -77,7 +77,7 @@ manifest and configuration information uses the new diff atop the old manifest.`
 		},
 		cli.BoolFlag{
 			Name:  "refresh-bundle",
-			Usage: "update the bundle metadata (mtree) to reflect the packed rootfs",
+			Usage: "update the bundle metadata to reflect the packed rootfs",
 		},
 	},
 

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -185,7 +185,7 @@ func unpack(ctx *cli.Context) error {
 		fsEval = fseval.RootlessFsEval
 	}
 
-	if err := writeMtree(mtreeName, bundlePath, fsEval); err != nil {
+	if err := generateBundleManifest(mtreeName, bundlePath, fsEval); err != nil {
 		return errors.Wrap(err, "write mtree")
 	}
 

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -150,7 +150,7 @@ func unpack(ctx *cli.Context) error {
 		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.MediaType), "invalid --image tag")
 	}
 
-	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), "sha256:", "sha256_", 1)
+	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), ":", "_", 1)
 	log.WithFields(log.Fields{
 		"image":  imagePath,
 		"bundle": bundlePath,

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -20,7 +20,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
@@ -32,7 +31,6 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"github.com/vbatts/go-mtree"
 	"golang.org/x/net/context"
 )
 
@@ -153,9 +151,6 @@ func unpack(ctx *cli.Context) error {
 	}
 
 	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), "sha256:", "sha256_", 1)
-	mtreePath := filepath.Join(bundlePath, mtreeName+".mtree")
-	fullRootfsPath := filepath.Join(bundlePath, layer.RootfsName)
-
 	log.WithFields(log.Fields{
 		"image":  imagePath,
 		"bundle": bundlePath,
@@ -185,32 +180,12 @@ func unpack(ctx *cli.Context) error {
 	}
 	log.Info("... done")
 
-	log.WithFields(log.Fields{
-		"keywords": MtreeKeywords,
-		"mtree":    mtreePath,
-	}).Debugf("umoci: generating mtree manifest")
-
 	fsEval := fseval.DefaultFsEval
 	if meta.MapOptions.Rootless {
 		fsEval = fseval.RootlessFsEval
 	}
 
-	log.Info("computing filesystem manifest ...")
-	dh, err := mtree.Walk(fullRootfsPath, nil, MtreeKeywords, fsEval)
-	if err != nil {
-		return errors.Wrap(err, "generate mtree spec")
-	}
-	log.Info("... done")
-
-	fh, err := os.OpenFile(mtreePath, os.O_EXCL|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return errors.Wrap(err, "open mtree")
-	}
-	defer fh.Close()
-
-	log.Debugf("umoci: saving mtree manifest")
-
-	if _, err := dh.WriteTo(fh); err != nil {
+	if err := writeMtree(mtreeName, bundlePath, fsEval); err != nil {
 		return errors.Wrap(err, "write mtree")
 	}
 

--- a/cmd/umoci/utils.go
+++ b/cmd/umoci/utils.go
@@ -247,9 +247,9 @@ func Stat(ctx context.Context, engine casext.Engine, manifestDescriptor ispec.De
 	return stat, nil
 }
 
-// writeMtree writes an mtree of the rootfs in the given bundle path into the
-// file by the given name, using the supplied fsEval method
-func writeMtree(mtreeName string, bundlePath string, fsEval mtree.FsEval) error {
+// generateBundleManifest creates and writes an mtree of the rootfs in the given
+// bundle path, using the supplied fsEval method
+func generateBundleManifest(mtreeName string, bundlePath string, fsEval mtree.FsEval) error {
 	mtreePath := filepath.Join(bundlePath, mtreeName+".mtree")
 	fullRootfsPath := filepath.Join(bundlePath, layer.RootfsName)
 

--- a/cmd/umoci/utils.go
+++ b/cmd/umoci/utils.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/apex/log"
 	"github.com/docker/go-units"
 	"github.com/openSUSE/umoci/oci/casext"
 	igen "github.com/openSUSE/umoci/oci/config/generate"
@@ -244,4 +245,38 @@ func Stat(ctx context.Context, engine casext.Engine, manifestDescriptor ispec.De
 	}
 
 	return stat, nil
+}
+
+// writeMtree writes an mtree of the rootfs in the given bundle path into the
+// file by the given name, using the supplied fsEval method
+func writeMtree(mtreeName string, bundlePath string, fsEval mtree.FsEval) error {
+	mtreePath := filepath.Join(bundlePath, mtreeName+".mtree")
+	fullRootfsPath := filepath.Join(bundlePath, layer.RootfsName)
+
+	log.WithFields(log.Fields{
+		"keywords": MtreeKeywords,
+		"mtree":    mtreePath,
+	}).Debugf("umoci: generating mtree manifest")
+
+	log.Info("computing filesystem manifest ...")
+	dh, err := mtree.Walk(fullRootfsPath, nil, MtreeKeywords, fsEval)
+	if err != nil {
+		return errors.Wrap(err, "generate mtree spec")
+	}
+	log.Info("... done")
+
+	flags := os.O_CREATE | os.O_WRONLY | os.O_EXCL
+	fh, err := os.OpenFile(mtreePath, flags, 0644)
+	if err != nil {
+		return errors.Wrap(err, "open mtree")
+	}
+	defer fh.Close()
+
+	log.Debugf("umoci: saving mtree manifest")
+
+	if _, err := dh.WriteTo(fh); err != nil {
+		return errors.Wrap(err, "write mtree")
+	}
+
+	return nil
 }

--- a/doc/man/umoci-repack.1.md
+++ b/doc/man/umoci-repack.1.md
@@ -11,6 +11,7 @@ umoci repack - Repacks an OCI runtime bundle into an image tag
 [**--history.created_by**=*created_by*]
 [**--history.author**=*author*]
 [**--history-created**=*date*]
+[**--refresh-bundle**]
 *bundle*
 
 # DESCRIPTION
@@ -61,6 +62,11 @@ The global options are defined in **umoci**(1).
   Creation date for the history entry corresponding to this modifications of
   the image. This must be an ISO8601 formatted timestamp (see **date**(1)). If
   unspecified, the current time is used.
+
+**--refresh-bundle**
+  Whether to update the OCI bundle's metadata (i.e. mtree and umoci
+  metadata) after repacking the image. If set, then the new state of
+  the bundle should be equivalent to unpacking the new image tag.
 
 # EXAMPLE
 The following downloads an image from a **docker**(1) registry using


### PR DESCRIPTION
When this flag is supplied, umoci will refresh the bundle's metadata
(namely, the mtree manifest and the umoci metadata JSON) to record the
state of the bundle when the repack is performed. This means that an
unpack immediately after a repack should be essentially idempotent.

Fixes #196

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>