### PR TITLE
test: correct test for --refresh-bundle

### DIFF
--- a/test/repack.bats
+++ b/test/repack.bats
@@ -686,6 +686,8 @@ function teardown() {
 
 	# Repack under a new tag again, without refreshing the metadata.
 	umoci repack --image "${IMAGE}:${TAG}-new2" "$BUNDLE_A"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
 
 	# Unpack it again into a new bundle.
 	umoci unpack --image "${IMAGE}:${TAG}-new2" "$BUNDLE_C"


### PR DESCRIPTION
Looks like I missed this on first-pass. This test didn't check that
umoci-repack succeeded in one of the cases. Add the corrected checks to
match the rest of the testing suite.

Signed-off-by: Aleksa Sarai <asarai@suse.de>