### PR TITLE
Makefile: remove volume mount of source directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,5 @@ ENV SOURCE_IMAGE=/opensuse SOURCE_TAG=latest
 ARG DOCKER_IMAGE=opensuse/amd64:tumbleweed
 RUN skopeo copy docker://$DOCKER_IMAGE oci:$SOURCE_IMAGE:$SOURCE_TAG
 
-VOLUME ["/go/src/github.com/openSUSE/umoci"]
 WORKDIR /go/src/github.com/openSUSE/umoci
 COPY . /go/src/github.com/openSUSE/umoci

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ CMD := ${PROJECT}/cmd/umoci
 
 # We use Docker because Go is just horrific to deal with.
 UMOCI_IMAGE := umoci_dev
+DOCKER_RUN := docker run --rm -it
 
 # Output directory.
 BUILD_DIR ?= .
@@ -80,7 +81,7 @@ clean:
 
 .PHONY: validate
 validate: umociimage
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) $(UMOCI_IMAGE) make local-validate
+	$(DOCKER_RUN) $(UMOCI_IMAGE) make local-validate
 
 .PHONY: local-validate
 local-validate: local-validate-git local-validate-go local-validate-reproducible local-validate-build
@@ -147,8 +148,8 @@ endif
 .PHONY: test-unit
 test-unit: umociimage
 	touch $(COVERAGE) && chmod a+rw $(COVERAGE)
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) --cap-add=SYS_ADMIN $(UMOCI_IMAGE) make local-test-unit
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-unit
+	$(DOCKER_RUN) -e COVERAGE=$(COVERAGE) --cap-add=SYS_ADMIN $(UMOCI_IMAGE) make local-test-unit
+	$(DOCKER_RUN) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-unit
 
 .PHONY: local-test-unit
 local-test-unit:
@@ -157,15 +158,15 @@ local-test-unit:
 .PHONY: test-integration
 test-integration: umociimage
 	touch $(COVERAGE) && chmod a+rw $(COVERAGE)
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) $(UMOCI_IMAGE) make local-test-integration
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-integration
+	$(DOCKER_RUN) -e COVERAGE=$(COVERAGE) $(UMOCI_IMAGE) make local-test-integration
+	$(DOCKER_RUN) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-integration
 
 .PHONY: local-test-integration
 local-test-integration: umoci.cover
 	COVER=1 hack/test-integration.sh
 
 shell: umociimage
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) $(UMOCI_IMAGE) bash
+	$(DOCKER_RUN) $(UMOCI_IMAGE) bash
 
 .PHONY: ci
 ci: umoci umoci.cover doc local-validate test-unit test-integration


### PR DESCRIPTION
_[update]_

With the current Makefile, the Docker variants of the tests don't work
out of the box on SELinux-enabled systems because the volume mount
(namely, the source directory) isn't labelled correctly.

However we're already copying in the source, and the volume mount (over
the top of it) was only really used for `make shell`. Since this is an
uncommon use case, let's just drop the volume mount completely.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>

--

_[original PR, now at #206]_
With the current Makefile, the Docker variants of the tests don't work
out of the box on SELinux-enabled systems because the volume mount
(namely, the source directory) isn't labelled correctly. This patch
simply disables SELinux labelling for these particular containers,
as the easiest way to mitigate this issue. (This seems preferable to
using the `:z` or `:Z` option to the Docker volume mount, which would
forceably relabel the directory every time the Docker command is run.)

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>