### PR TITLE
*: clean some old deprecated comments

### DIFF
--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -27,11 +27,6 @@ import (
 	"github.com/vbatts/go-mtree"
 )
 
-// NOTE: This currently requires a version of go-mtree which has my Compare()
-//       PR added. While we don't use this interface here, my work also
-//       implemented the InodeDelta and supporting interfaces. Hopefully my PR
-//       will be merged soon. https://github.com/vbatts/go-mtree/pull/48
-
 // inodeDeltas is a wrapper around []mtree.InodeDelta that allows for sorting
 // the set of deltas by the pathname.
 type inodeDeltas []mtree.InodeDelta

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -101,11 +101,11 @@ function umoci() {
 function gomtree() {
 	local args=("$@")
 
-	# We're rootless. Note that this is _not_ available from the upstream
-	# version of go-mtree. It's a feature I implemented in the library for
-	# umoci's support, and is currently being proposed in
-	# https://github.com/vbatts/go-mtree/pull/96. I would not hold my breath
-	# that it'll be merged any time soon.
+	# We're rootless. Note that this is _not_ available in the upstream
+	# version of go-mtree and is unlikely to be accepted there (see
+	# https://github.com/vbatts/go-mtree/pull/96).
+	# It's maintained instead as an openSUSE extension:
+	# https://build.opensuse.org/package/view_file/Virtualization:containers/go-mtree/0001-gomtree-add-rootless-flag.patch?expand=1
 	if [[ "$ROOTLESS" != 0 ]]; then
 		args+=("-rootless")
 	fi

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -46,7 +46,6 @@ function teardown() {
 	echo "first file" > "$BUNDLE_A/rootfs/newfile"
 	mkdir "$BUNDLE_A/rootfs/newdir"
 	echo "subfile" > "$BUNDLE_A/rootfs/newdir/anotherfile"
-	# this currently breaks go-mtree but I've backported a patch to fix it in openSUSE
 	ln -s "this is a dummy symlink" "$BUNDLE_A/rootfs/newdir/link"
 
 	# Repack the image under a new tag.
@@ -184,7 +183,6 @@ function teardown() {
 	chmod +w "$BUNDLE_A/rootfs/bin/." && rm "$BUNDLE_A/rootfs/bin/sh"
 	mkdir "$BUNDLE_A/rootfs/bin/sh"
 	chmod +w "$BUNDLE_A/rootfs/usr/bin/." && rm "$BUNDLE_A/rootfs/usr/bin/env"
-	# this currently breaks go-mtree but I've backported a patch to fix it in openSUSE
 	ln -s "a \\really //weird _00..:=path " "$BUNDLE_A/rootfs/usr/bin/env"
 
 	# Repack the image under the same tag.


### PR DESCRIPTION
There were various references to patched versions of go-mtree, but all
mentioned fixes are now in the upstream version that umoci is using.

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>