### PR TITLE
Makefile: add option to specify individual test(s)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,12 @@ local-test-unit:
 .PHONY: test-integration
 test-integration: umociimage
 	touch $(COVERAGE) && chmod a+rw $(COVERAGE)
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) $(UMOCI_IMAGE) make local-test-integration
-	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make local-test-integration
+	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) $(UMOCI_IMAGE) make TESTS="${TESTS}" local-test-integration
+	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) -e COVERAGE=$(COVERAGE) -u 1000:1000 --cap-drop=all $(UMOCI_IMAGE) make TESTS="${TESTS}" local-test-integration
 
 .PHONY: local-test-integration
 local-test-integration: umoci.cover
-	COVER=1 hack/test-integration.sh
+	TESTS="${TESTS}" COVER=1 hack/test-integration.sh
 
 shell: umociimage
 	docker run --rm -it -v $(PWD):/go/src/$(PROJECT) $(UMOCI_IMAGE) bash

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -33,7 +33,15 @@ if [ "$COVER" -eq 1 ]; then
 fi
 
 # Run the tests and collate the results.
-bats -t $ROOT/test/*.bats
+tests=()
+if [[ -z "$TESTS" ]]; then
+	tests=($ROOT/test/*.bats)
+else
+	for f in $TESTS; do
+		tests+=("$ROOT/test/$f.bats")
+	done
+fi
+bats -t ${tests[*]}
 if [ "$COVER" -eq 1 ]; then
 	[ "$COVERAGE" ] && $ROOT/hack/collate.awk $COVERAGE_DIR/* $COVERAGE | sponge $COVERAGE
 fi


### PR DESCRIPTION
Running all the integration tests can be a bit tedious when a developer
is iterating on a particular subcommand. This adds the ability to
specify a subset of tests by passing the `TESTS=` argument to the
`test-integration` and `local-test-integration` Make targets. This
argument expects the name of one or more tests, each of which is
expected to match a .bats file in the `tests/` directory. If unset, we
continue to default to running all tests.

Examples:
  $ make TESTS="gc" test-integration
  $ make TESTS="unpack repack" local-test-integration
  $ make test-integration

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>