### PR TITLE
test: change oci-image-validate reference

### DIFF
--- a/test/create.bats
+++ b/test/create.bats
@@ -85,13 +85,13 @@ function teardown() {
 	# Create a new image with another tag.
 	umoci new --image "${NEWIMAGE}:latest"
 	[ "$status" -eq 0 ]
-	# XXX: oci-image-validate doesn't like empty images (without layers)
+	# XXX: oci-image-tool validate doesn't like empty images (without layers)
 	#image-verify "$NEWIMAGE"
 
 	# Modify the config.
 	umoci config --image "${NEWIMAGE}" --config.user "1234:1332"
 	[ "$status" -eq 0 ]
-	# XXX: oci-image-validate doesn't like empty images (without layers)
+	# XXX: oci-image-tool validate doesn't like empty images (without layers)
 	#image-verify "$NEWIMAGE"
 
 	# Unpack the image.
@@ -125,6 +125,6 @@ function teardown() {
 	# There should be no non-empty_layers.
 	[[ "$(echo "$output" | jq -SM '[.history[] | .empty_layer == null] | any')" == "false" ]]
 
-	# XXX: oci-image-validate doesn't like empty images (without layers)
+	# XXX: oci-image-tool validate doesn't like empty images (without layers)
 	#image-verify "$NEWIMAGE"
 }

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -51,7 +51,7 @@ function requires() {
 }
 
 function image-verify() {
-	oci-image-validate --type "imageLayout" "$@"
+	oci-image-tool validate --type "imageLayout" "$@"
 	return $?
 }
 


### PR DESCRIPTION
As of
https://github.com/opencontainers/image-tools/commit/1423c5e01935372d9f069e158f11a0f1b43df221,
oci-image-tools moved the individual commands into subcommands (i.e.
`oci-image-validate` became `oci-image-tool validate`. The umoci
development Dockerfile installs a very old version of the OCI image
tools [1][1] before this merge happened; and although it installs a
specific (newer) version of the image tools "over the top" [2][2],
during the tests we were specifically calling `oci-image-validate` which
would invoke the old version.

[1]: https://github.com/openSUSE/umoci/blob/80f8d32c23772c3d9f20d02f82fd6a60186c0e92/Dockerfile#L35
[2]: https://github.com/openSUSE/umoci/blob/80f8d32c23772c3d9f20d02f82fd6a60186c0e92/Dockerfile#L67

Signed-off-by: Jonathan Boulle <jonathanboulle@gmail.com>