### PR TITLE
oci: walk: ignore unknown mediatypes

### DIFF
--- a/oci/cas/cas.go
+++ b/oci/cas/cas.go
@@ -46,6 +46,11 @@ var (
 	// ErrInvalid is returned when an image was detected as being invalid.
 	ErrInvalid = fmt.Errorf("invalid image detected")
 
+	// ErrUnknownType is returned when an unknown (or otherwise unparseable)
+	// mediatype is encountered. Callers should not ignore this error unless it
+	// is in a context where ignoring it is more friendly to spec extensions.
+	ErrUnknownType = fmt.Errorf("unknown mediatype encountered")
+
 	// ErrNotImplemented is returned when a requested operation has not been
 	// implementing the backing image store.
 	ErrNotImplemented = fmt.Errorf("operation not implemented")

--- a/oci/casext/blob.go
+++ b/oci/casext/blob.go
@@ -113,7 +113,7 @@ func (b *Blob) load(ctx context.Context, engine cas.Engine) error {
 		b.Data = parsed
 
 	default:
-		return fmt.Errorf("cas blob: unsupported mediatype: %s", b.MediaType)
+		return cas.ErrUnknownType
 	}
 
 	if b.Data == nil {


### PR DESCRIPTION
This is to make our handling of OCI extensions much nicer when walking
over blobs.

Replacement for #104.
Signed-off-by: Aleksa Sarai <asarai@suse.de>