### PR TITLE
 layer: improve warnings in rootless mode

### DIFF
--- a/doc/site/quick-start/rootless.md
+++ b/doc/site/quick-start/rootless.md
@@ -23,8 +23,8 @@ behaviour.
 % id -u
 1000
 % umoci unpack --rootless --image opensuse:42.2 bundle
-   • restoreMetadata: ignoring EPERM on setxattr: security.capability: unpriv.lsetxattr: operation not permitted
-   • restoreMetadata: ignoring EPERM on setxattr: security.capability: unpriv.lsetxattr: operation not permitted
+   • rootless{usr/bin/ping} ignoring (usually) harmless EPERM on setxattr "security.capability"
+   • rootless{usr/bin/ping6} ignoring (usually) harmless EPERM on setxattr "security.capability"
 % runc run -b bundle rootless-ctr
 bash-4.3# whoami
 root


### PR DESCRIPTION
It appears that golang.org/x/sys/unix doesn't add path information to
errors (and only return the syscall.Errno). While this is fine, it
caused rootless warnings to be needlessly confusing. In addition, the
warnings looked too scary before. Hopefully they seem less worrying now.

In addition, add a new warning when we fake a device inode. Most of the
container images I've tested don't appear to contain them, so the
warning isn't too spammy (and also it doesn't look as worrying
hopefully).

/cc @davidcassany 
Signed-off-by: Aleksa Sarai <asarai@suse.de>