### PR TITLE
ci: make test coverage have a cutoff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,5 +170,4 @@ shell: umociimage
 
 .PHONY: ci
 ci: umoci umoci.cover doc local-validate test-unit test-integration
-	$(GO) tool cover -func <(egrep -v 'vendor|third_party' $(COVERAGE)) | egrep -v '^total:' | sort -k 3gr
-	$(GO) tool cover -func <(egrep -v 'vendor|third_party' $(COVERAGE)) | egrep    '^total:'
+	hack/ci-coverage.sh $(COVERAGE)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CMD := ${PROJECT}/cmd/umoci
 
 # We use Docker because Go is just horrific to deal with.
 UMOCI_IMAGE := umoci_dev
-DOCKER_RUN := docker run --rm -it --security-opt label:disable -v ${PWD}:/go/src/${PROJECT}
+DOCKER_RUN := docker run --rm -it --security-opt apparmor:unconfined --security-opt label:disable -v ${PWD}:/go/src/${PROJECT}
 
 # Output directory.
 BUILD_DIR ?= .

--- a/hack/ci-coverage.sh
+++ b/hack/ci-coverage.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (C) 2018 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -o pipefail
+
+COVERAGE="$1"
+
+function coverage() {
+	go tool cover -func <(egrep -v 'vendor|third_party' "$@")
+}
+
+# Sort the coverage of all of the functions. This helps eye-ball what parts of
+# the project don't have enough test coverage.
+coverage "$COVERAGE" | egrep -v '^total:' | sort -k 3gr
+
+# Now find the coverage percentage, to check against the hardcoded lower limit.
+TOTAL="$(coverage "$COVERAGE" | grep '^total:' | sed -E 's|^[^[:digit:]]*([[:digit:]]+\.[[:digit:]]+)%$|\1|')"
+CUTOFF="80.0"
+
+echo "=== TOTAL COVERAGE: ${TOTAL}% ==="
+if (( "$(echo "$TOTAL < $CUTOFF" | bc)" ))
+then
+	echo "ERROR: Test coverage has fallen below hard cutoff of $CUTOFF."
+	echo "       Failing this CI run, as test coverage is a hard limit."
+	exit 64
+fi

--- a/oci/layer/tar_unix.go
+++ b/oci/layer/tar_unix.go
@@ -23,16 +23,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// These values come from new_decode_dev() inside <linux/kdev_t.h>.
-func major(device uint64) uint64 {
-	return (device & 0xfff00) >> 8
-}
-
-// These values come from new_decode_dev() inside <linux/kdev_t.h>.
-func minor(device uint64) uint64 {
-	return (device & 0xff) | ((device >> 12) & 0xfff00)
-}
-
 func updateHeader(hdr *tar.Header, s unix.Stat_t) {
 	// Currently the Go stdlib doesn't fill in the major/minor numbers of
 	// devices, so we have to do it manually.

--- a/pkg/system/mknod_linux_test.go
+++ b/pkg/system/mknod_linux_test.go
@@ -1,6 +1,6 @@
 /*
  * umoci: Umoci Modifies Open Containers' Images
- * Copyright (C) 2016, 2017 SUSE LLC.
+ * Copyright (C) 2016, 2017, 2018 SUSE LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,29 @@
 
 package system
 
-import "golang.org/x/sys/unix"
+import (
+	"archive/tar"
+	"testing"
 
-// Unlink is a wrapper around unlink(2).
-func Unlink(path string) error {
-	return unix.Unlink(path)
+	"golang.org/x/sys/unix"
+)
+
+// Exhaustive test for Tarmode mapping.
+func TestTarmode(t *testing.T) {
+	for _, test := range []struct {
+		typeflag byte
+		mode     uint32
+	}{
+		{tar.TypeReg, 0},
+		{tar.TypeSymlink, unix.S_IFLNK},
+		{tar.TypeChar, unix.S_IFCHR},
+		{tar.TypeBlock, unix.S_IFBLK},
+		{tar.TypeFifo, unix.S_IFIFO},
+		{tar.TypeDir, unix.S_IFDIR},
+	} {
+		mode := Tarmode(test.typeflag)
+		if mode != test.mode {
+			t.Errorf("got unexpected mode %x with tar typeflag %x, expected %x", mode, test.typeflag, test.mode)
+		}
+	}
 }


### PR DESCRIPTION
In order to avoid the CI from slowly becoming less and less reliable,
enforce a hard coverage cutoff for the entire project. 80% should be
good enough for the moment.

Closes #154 
Signed-off-by: Aleksa Sarai <asarai@suse.de>