### PR TITLE
oci: tar extract: full opaque whiteout support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   fork][as-proot-fork] (though we do not test its interoperability at the
   moment) as both tools use [the same protobuf
   specification][rootlesscontainers-proto]. openSUSE/umoci#227
+- `umoci unpack` now has support for opaque whiteouts (whiteouts which remove
+  all children of a directory in the lower layer), though `umoci repack` does
+  not currently have support for generating them. While this is technically a
+  spec requirement, through testing we've never encountered an actual user of
+  these whiteouts. openSUSE/umoci#224 openSUSE/umoci#229
 
 ### Fixed
 - Fix a bug in our "parent directory restore" code, which is responsible for

--- a/pkg/fseval/fseval.go
+++ b/pkg/fseval/fseval.go
@@ -19,6 +19,7 @@ package fseval
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/vbatts/go-mtree"
@@ -95,4 +96,7 @@ type FsEval interface {
 
 	// KeywordFunc returns a wrapper around the given mtree.KeywordFunc.
 	KeywordFunc(fn mtree.KeywordFunc) mtree.KeywordFunc
+
+	// Walk is equivalent to filepath.Walk.
+	Walk(root string, fn filepath.WalkFunc) error
 }

--- a/pkg/fseval/fseval_default.go
+++ b/pkg/fseval/fseval_default.go
@@ -19,6 +19,7 @@ package fseval
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/openSUSE/umoci/pkg/system"
@@ -145,4 +146,9 @@ func (fs osFsEval) Lclearxattrs(path string) error {
 // KeywordFunc returns a wrapper around the given mtree.KeywordFunc.
 func (fs osFsEval) KeywordFunc(fn mtree.KeywordFunc) mtree.KeywordFunc {
 	return fn
+}
+
+// Walk is equivalent to filepath.Walk.
+func (fs osFsEval) Walk(root string, fn filepath.WalkFunc) error {
+	return filepath.Walk(root, fn)
 }

--- a/pkg/fseval/fseval_rootless.go
+++ b/pkg/fseval/fseval_rootless.go
@@ -20,6 +20,7 @@ package fseval
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/openSUSE/umoci/pkg/unpriv"
@@ -147,4 +148,9 @@ func (fs unprivFsEval) KeywordFunc(fn mtree.KeywordFunc) mtree.KeywordFunc {
 		})
 		return kv, err
 	}
+}
+
+// Walk is equivalent to filepath.Walk.
+func (fs unprivFsEval) Walk(root string, fn filepath.WalkFunc) error {
+	return unpriv.Walk(root, fn)
 }

--- a/pkg/unpriv/unpriv.go
+++ b/pkg/unpriv/unpriv.go
@@ -19,7 +19,6 @@ package unpriv
 
 import (
 	"archive/tar"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,6 +55,11 @@ func splitpath(path string) []string {
 	return parts
 }
 
+// WrapFunc is a function that can be passed to Wrap. It takes a path (and
+// presumably operates on it -- since Wrap only ensures that the path given is
+// resolvable) and returns some form of error.
+type WrapFunc func(path string) error
+
 // Wrap will wrap a given function, and call it in a context where all of the
 // parent directories in the given path argument are such that the path can be
 // resolved (you may need to make your own changes to the path to make it
@@ -63,7 +67,7 @@ func splitpath(path string) []string {
 // if the error returned is such that !os.IsPermission(err), then no trickery
 // will be performed. If fn returns an error, so will this function. All of the
 // trickery is reverted when this function returns (which is when fn returns).
-func Wrap(path string, fn func(path string) error) error {
+func Wrap(path string, fn WrapFunc) error {
 	// FIXME: Should we be calling fn() here first?
 	if err := fn(path); err == nil || !os.IsPermission(errors.Cause(err)) {
 		return err
@@ -299,10 +303,50 @@ func Remove(path string) error {
 	return errors.Wrap(Wrap(path, os.Remove), "unpriv.remove")
 }
 
-// RemoveAll is similar to os.RemoveAll but in order to implement it properly
-// all of the internal functions were wrapped with unpriv.Wrap to make it
-// possible to remove a path (even if it has child paths) even if you do not
-// currently have enough access bits.
+// foreachSubpath executes WrapFunc for each child of the given path (not
+// including the path itself). If path is not a directory, then WrapFunc will
+// not be called and no error will be returned. This should be called within a
+// context where path has already been made resolveable. If WrapFunc returns an
+// error, the first error is returned and iteration is halted.
+func foreachSubpath(path string, wrapFn WrapFunc) error {
+	// Is the path a directory?
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !fi.IsDir() {
+		return nil
+	}
+
+	// Open the directory.
+	fd, err := Open(path)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer fd.Close()
+
+	// We need to change the mode to Readdirnames. We don't need to worry about
+	// permissions because we're already in a context with filepath.Dir(path)
+	// is at least a+rx.
+	os.Chmod(path, fi.Mode()|0400)
+	defer fiRestore(path, fi)
+
+	// Remove contents recursively.
+	names, err := fd.Readdirnames(-1)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	for _, name := range names {
+		if err := wrapFn(filepath.Join(path, name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RemoveAll is similar to os.RemoveAll but with all of the internal functions
+// wrapped with unpriv.Wrap to make it possible to remove a path (even if it
+// has child paths) even if you do not currently have enough access bits.
 func RemoveAll(path string) error {
 	return errors.Wrap(Wrap(path, func(path string) error {
 		// If remove works, we're done.
@@ -324,49 +368,25 @@ func RemoveAll(path string) error {
 		if !fi.IsDir() {
 			return errors.Wrap(err, "remove non-directory")
 		}
-
-		// Open the directory.
-		fd, err := Open(path)
-		if err != nil {
-			// We hit a race, but don't worry about it.
-			if os.IsNotExist(errors.Cause(err)) {
-				err = nil
-			}
-			return errors.Wrap(err, "opendir")
-		}
-
-		// We need to change the mode to Readdirnames. We don't need to worry
-		// about permissions because we're already in a context with
-		// filepath.Dir(path) is writeable.
-		os.Chmod(path, fi.Mode()|0400)
-		defer fiRestore(path, fi)
-
-		// Remove contents recursively.
 		err = nil
-		for {
-			names, err1 := fd.Readdirnames(128)
-			for _, name := range names {
-				err1 := RemoveAll(filepath.Join(path, name))
-				if err == nil {
-					err = err1
-				}
-			}
-			if err1 == io.EOF {
-				break
-			}
-			if err == nil {
-				err = err1
-			}
-			if len(names) == 0 {
-				break
-			}
-		}
 
-		// Close the directory.
-		fd.Close()
+		err1 := foreachSubpath(path, func(subpath string) error {
+			err2 := RemoveAll(subpath)
+			if err == nil {
+				err = err2
+			}
+			return nil
+		})
+		if err1 != nil {
+			// We must have hit a race, but we don't care.
+			if os.IsNotExist(errors.Cause(err1)) {
+				err1 = nil
+			}
+			return errors.Wrap(err1, "foreach subpath")
+		}
 
 		// Remove the directory. This should now work.
-		err1 := os.Remove(path)
+		err1 = os.Remove(path)
 		if err1 == nil || os.IsNotExist(errors.Cause(err1)) {
 			return nil
 		}


### PR DESCRIPTION
Add full opaque whiteout support, including the handling of new files
present in the upper layer (and thus should not be removed). The code
implementing this is fairly fragile and has to deal with a lot of really
annoying edge cases, so many new tests were added for this portion.

There are a few semantics differences found between unpriv.Walk and
filepath.Walk by this patch (especially when it comes to handling ENOENT
during the walk). These semantics have been fixed in the WalkFunc used,
but probably deserve a refactor in future.

Closes #224 
Signed-off-by: Aleksa Sarai <asarai@suse.de>