### PR TITLE
oci: tar extract: handle out-of-order regular whiteouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- `umoci unpack` now handles out-of-order regular whiteouts correctly (though
+  this ordering is not recommended by the spec -- nor is it required). This is
+  an extension of openSUSE/umoci#229 that was missed during review.
+  openSUSE/umoci#232
 
 ## [0.4.0] - 2018-03-10
 ### Added


### PR DESCRIPTION
08da5c6d0fd9 ("oci: tar extract: full opaque whiteout support") added
handling for opaque whiteouts such that out-of-order whiteouts were
still handled correctly. However, this new handling wasn't extended to
regular whiteouts (which have effectively the same semantics).

Correct this by refactoring out the removal function we crafted for
opaque whiteouts and just use it for all whiteouts.

Closes #224 (again).
Signed-off-by: Aleksa Sarai <asarai@suse.de>