### PR TITLE
add `umoci insert` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ update-deps:
 
 .PHONY: clean
 clean:
-	rm -f umoci umoci.static
+	rm -f umoci umoci.static umoci.cov*
 	rm -f $(MANPAGES)
 
 .PHONY: validate

--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -1,0 +1,140 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 Cisco
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/openSUSE/umoci/mutate"
+	"github.com/openSUSE/umoci/oci/cas/dir"
+	"github.com/openSUSE/umoci/oci/casext"
+	igen "github.com/openSUSE/umoci/oci/config/generate"
+	"github.com/openSUSE/umoci/oci/layer"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+var insertCommand = uxHistory(cli.Command{
+	Name:  "insert",
+	Usage: "insert a file into an OCI image without unpacking/repacking it",
+	ArgsUsage: `--image <image-path>[:<tag>] <file> <path>
+
+Where "<image-path>" is the path to the OCI image, "<tag>" is the name of the
+tag that the content wil be inserted into (if not specified, defaults to
+"latest"), "<file>" is the file or folder to insert, and "<path>" is the prefix
+inside the image to insert it into.`,
+
+	Category: "image",
+
+	Action: insert,
+
+	Before: func(ctx *cli.Context) error {
+		if ctx.NArg() != 2 {
+			return errors.Errorf("invalid number of positional arguments: expected <file> and <path>")
+		}
+		if ctx.Args()[0] == "" {
+			return errors.Errorf("path cannot be empty")
+		}
+		if ctx.Args()[1] == "" {
+			return errors.Errorf("path cannot be empty")
+		}
+		return nil
+	},
+})
+
+func insert(ctx *cli.Context) error {
+	imagePath := ctx.App.Metadata["--image-path"].(string)
+	tagName := ctx.App.Metadata["--image-tag"].(string)
+
+	// Get a reference to the CAS.
+	engine, err := dir.Open(imagePath)
+	if err != nil {
+		return errors.Wrap(err, "open CAS")
+	}
+	engineExt := casext.NewEngine(engine)
+	defer engine.Close()
+
+	descriptorPaths, err := engineExt.ResolveReference(context.Background(), tagName)
+	if err != nil {
+		return errors.Wrap(err, "get descriptor")
+	}
+	if len(descriptorPaths) == 0 {
+		return errors.Errorf("tag not found: %s", tagName)
+	}
+	if len(descriptorPaths) != 1 {
+		// TODO: Handle this more nicely.
+		return errors.Errorf("tag is ambiguous: %s", tagName)
+	}
+
+	// Create the mutator.
+	mutator, err := mutate.New(engine, descriptorPaths[0])
+	if err != nil {
+		return errors.Wrap(err, "create mutator for base image")
+	}
+
+	// TODO: add some way to specify these from the cli
+	reader := layer.GenerateInsertLayer(ctx.Args()[0], ctx.Args()[1], nil)
+	defer reader.Close()
+
+	created := time.Now()
+	history := ispec.History{
+		Comment:    "",
+		Created:    &created,
+		CreatedBy:  "umoci insert", // XXX: Should we append argv to this?
+		EmptyLayer: false,
+	}
+
+	if val, ok := ctx.App.Metadata["--history.author"]; ok {
+		history.Author = val.(string)
+	}
+	if val, ok := ctx.App.Metadata["--history.comment"]; ok {
+		history.Comment = val.(string)
+	}
+	if val, ok := ctx.App.Metadata["--history.created"]; ok {
+		created, err := time.Parse(igen.ISO8601, val.(string))
+		if err != nil {
+			return errors.Wrap(err, "parsing --history.created")
+		}
+		history.Created = &created
+	}
+	if val, ok := ctx.App.Metadata["--history.created_by"]; ok {
+		history.CreatedBy = val.(string)
+	}
+
+	// TODO: We should add a flag to allow for a new layer to be made
+	//       non-distributable.
+	if err := mutator.Add(context.Background(), reader, history); err != nil {
+		return errors.Wrap(err, "add diff layer")
+	}
+
+	newDescriptorPath, err := mutator.Commit(context.Background())
+	if err != nil {
+		return errors.Wrap(err, "commit mutated image")
+	}
+
+	log.Infof("new image manifest created: %s->%s", newDescriptorPath.Root().Digest, newDescriptorPath.Descriptor().Digest)
+
+	if err := engineExt.UpdateReference(context.Background(), tagName, newDescriptorPath.Root()); err != nil {
+		return errors.Wrap(err, "add new tag")
+	}
+	log.Infof("updated tag for image manifest: %s", tagName)
+	return nil
+}

--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -1,5 +1,6 @@
 /*
  * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2016, 2017, 2018 SUSE LLC.
  * Copyright (C) 2018 Cisco
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/umoci/main.go
+++ b/cmd/umoci/main.go
@@ -111,6 +111,7 @@ func main() {
 		tagListCommand,
 		statCommand,
 		rawSubcommand,
+		insertCommand,
 	}
 
 	app.Metadata = map[string]interface{}{}

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/apex/log"
 	"github.com/openSUSE/umoci/pkg/unpriv"
@@ -107,7 +106,6 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *MapOptions) (io.
 func GenerateInsertLayer(root string, prefix string, opt *MapOptions) io.ReadCloser {
 	root = path.Clean(root)
 	rootPrefixLen := len(root) - len(path.Base(root))
-	prefix = strings.TrimPrefix(prefix, "/")
 
 	var mapOptions MapOptions
 	if opt != nil {

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/openSUSE/umoci/pkg/unpriv"
 	"github.com/pkg/errors"
 	"github.com/vbatts/go-mtree"
 )
@@ -124,7 +125,7 @@ func GenerateInsertLayer(root string, prefix string, opt *MapOptions) io.ReadClo
 
 		tg := newTarGenerator(writer, mapOptions)
 
-		err = filepath.Walk(root, func(curPath string, info os.FileInfo, err error) error {
+		err = unpriv.Walk(root, func(curPath string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -104,7 +104,7 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *MapOptions) (io.
 // GenerateInsertLayer generates a completely new layer from the root path to
 // be inserted into the image at "prefix".
 func GenerateInsertLayer(root string, prefix string, opt *MapOptions) io.ReadCloser {
-	root = path.Clean(root)
+	root = CleanPath(root)
 	rootPrefixLen := len(root) - len(path.Base(root))
 
 	var mapOptions MapOptions

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -102,10 +102,9 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *MapOptions) (io.
 }
 
 // GenerateInsertLayer generates a completely new layer from the root path to
-// be inserted into the image at "prefix".
-func GenerateInsertLayer(root string, prefix string, opt *MapOptions) io.ReadCloser {
+// be inserted into the image at "target".
+func GenerateInsertLayer(root string, target string, opt *MapOptions) io.ReadCloser {
 	root = CleanPath(root)
-	rootPrefixLen := len(root) - len(path.Base(root))
 
 	var mapOptions MapOptions
 	if opt != nil {
@@ -128,7 +127,7 @@ func GenerateInsertLayer(root string, prefix string, opt *MapOptions) io.ReadClo
 				return err
 			}
 
-			pathInTar := path.Join(prefix, curPath[rootPrefixLen:])
+			pathInTar := path.Join(target, curPath[len(root):])
 			return tg.AddFile(pathInTar, curPath)
 		})
 		if err != nil {

--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -88,6 +88,10 @@ func normalise(rawPath string, isDir bool) (string, error) {
 		return ".", nil
 	}
 
+	if filepath.IsAbs(path) {
+		path = strings.TrimPrefix(path, "/")
+	}
+
 	// Check that the path is "safe", meaning that it doesn't resolve outside
 	// of the tar archive. While this might seem paranoid, it is a legitimate
 	// concern.

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2018 Cisco
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+load helpers
+
+function setup() {
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci insert" {
+	image-verify "${IMAGE}"
+
+	# fail with too few arguments
+	umoci insert --image "${IMAGE}:${TAG}"
+	[ "$status" -ne 0 ]
+
+	# ...and too many
+	umoci insert --image "${IMAGE}:${TAG}" asdf 123 456
+	[ "$status" -ne 0 ]
+
+	# do the insert
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test/insert.bats" /tester
+	[ "$status" -eq 0 ]
+
+	# ...and check to make sure it worked
+	BUNDLE=$(setup_tmpdir)
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ -f "$BUNDLE/rootfs/tester/insert.bats" ]
+}

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -41,7 +41,7 @@ function teardown() {
 	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test/insert.bats" /tester/insert.bats
 	[ "$status" -eq 0 ]
 
-	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/umoci" /tester/umoci
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/umoci.cover" /tester/umoci.cover
 	[ "$status" -eq 0 ]
 
 	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test" /recursive
@@ -51,7 +51,7 @@ function teardown() {
 	BUNDLE=$(setup_tmpdir)
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ -f "$BUNDLE/rootfs/tester/insert.bats" ]
-	[ "$(stat --format=%f ${ROOT}/umoci)" == "$(stat --format=%f ${BUNDLE}/rootfs/tester/umoci)" ]
+	[ "$(stat --format=%f ${ROOT}/umoci.cover)" == "$(stat --format=%f ${BUNDLE}/rootfs/tester/umoci.cover)" ]
 	[ -f "$BUNDLE/rootfs/recursive/insert.bats" ]
 }
 
@@ -64,5 +64,5 @@ function teardown() {
 	mkdir -p $BUNDLE/rootfs/some/path
 	chmod 000 $BUNDLE/rootfs/some/path
 	umoci repack "${IMAGE}:${TAG}" "$BUNDLE"
-	umoci insert "${ROOT}/umoci" /some/path/umoci
+	umoci insert "${ROOT}/tester/insert.bats" /some/path/insert.bats
 }

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -37,12 +37,16 @@ function teardown() {
 	umoci insert --image "${IMAGE}:${TAG}" asdf 123 456
 	[ "$status" -ne 0 ]
 
-	# do the insert
+	# do an insert
 	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test/insert.bats" /tester
+	[ "$status" -eq 0 ]
+
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/umoci" /tester
 	[ "$status" -eq 0 ]
 
 	# ...and check to make sure it worked
 	BUNDLE=$(setup_tmpdir)
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ -f "$BUNDLE/rootfs/tester/insert.bats" ]
+	[ "$(stat --format=%f ${ROOT}/umoci)" == "$(stat --format=%f ${BUNDLE}/rootfs/tester/umoci)" ]
 }

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -54,3 +54,15 @@ function teardown() {
 	[ "$(stat --format=%f ${ROOT}/umoci)" == "$(stat --format=%f ${BUNDLE}/rootfs/tester/umoci)" ]
 	[ -f "$BUNDLE/rootfs/recursive/insert.bats" ]
 }
+
+@test "umoci insert rootless" {
+	image-verify "${IMAGE}"
+
+	BUNDLE=$(setup_tmpdir)
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+
+	mkdir -p $BUNDLE/rootfs/some/path
+	chmod 000 $BUNDLE/rootfs/some/path
+	umoci repack "${IMAGE}:${TAG}" "$BUNDLE"
+	umoci insert "${ROOT}/umoci" /some/path/umoci
+}

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -37,11 +37,14 @@ function teardown() {
 	umoci insert --image "${IMAGE}:${TAG}" asdf 123 456
 	[ "$status" -ne 0 ]
 
-	# do an insert
-	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test/insert.bats" /tester
+	# do a few inserts
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test/insert.bats" /tester/insert.bats
 	[ "$status" -eq 0 ]
 
-	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/umoci" /tester
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/umoci" /tester/umoci
+	[ "$status" -eq 0 ]
+
+	umoci insert --image "${IMAGE}:${TAG}" "${ROOT}/test" /recursive
 	[ "$status" -eq 0 ]
 
 	# ...and check to make sure it worked
@@ -49,4 +52,5 @@ function teardown() {
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ -f "$BUNDLE/rootfs/tester/insert.bats" ]
 	[ "$(stat --format=%f ${ROOT}/umoci)" == "$(stat --format=%f ${BUNDLE}/rootfs/tester/umoci)" ]
+	[ -f "$BUNDLE/rootfs/recursive/insert.bats" ]
 }


### PR DESCRIPTION
There are cases where you only want to insert files into an image. Right
now the procedure is: unpack the image, add the files, and repack the
image. However, the OCI format lends itself exactly to this kind of
addition -- we can just add a new layer with the files we wish to insert.
Additional motivation is in the case of large layers, we can avoid a lot of
i/o, CPU time to compress, and disk space requirements.

So, let's add a command to generate this new import layer.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>