### PR TITLE
umoci: add "raw unpack"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   alphanum  ::= [A-Za-z0-9]+
   separator ::= [-._:@+] | "--"
   ```
+- A new `umoci insert` subcommand which adds a given file to a path inside the
+  container. openSUSE/umoci#237
+- A new `umoci raw unpack` subcommand in order to allow users to unpack images
+  without needing a configuration or any of the manifest generation.
+  openSUSE/umoci#239
 
 ### Fixed
 - `umoci unpack` now handles out-of-order regular whiteouts correctly (though

--- a/cmd/umoci/raw-unpack.go
+++ b/cmd/umoci/raw-unpack.go
@@ -1,0 +1,131 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/openSUSE/umoci/oci/cas/dir"
+	"github.com/openSUSE/umoci/oci/casext"
+	"github.com/openSUSE/umoci/oci/layer"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"golang.org/x/net/context"
+)
+
+var rawUnpackCommand = uxRemap(cli.Command{
+	Name:  "unpack",
+	Usage: "unpacks a reference into a rootfs",
+	ArgsUsage: `--image <image-path>[:<tag>] <rootfs>
+
+Where "<image-path>" is the path to the OCI image, "<tag>" is the name of the
+tagged image to unpack (if not specified, defaults to "latest") and "<rootfs>"
+is the destination to unpack the image to.`,
+
+	// unpack reads manifest information.
+	Category: "image",
+
+	Flags: []cli.Flag{},
+
+	Action: rawUnpack,
+
+	Before: func(ctx *cli.Context) error {
+		if ctx.NArg() != 1 {
+			return errors.Errorf("invalid number of positional arguments: expected <rootfs>")
+		}
+		if ctx.Args().First() == "" {
+			return errors.Errorf("rootfs path cannot be empty")
+		}
+		ctx.App.Metadata["rootfs"] = ctx.Args().First()
+		return nil
+	},
+})
+
+func rawUnpack(ctx *cli.Context) error {
+	imagePath := ctx.App.Metadata["--image-path"].(string)
+	fromName := ctx.App.Metadata["--image-tag"].(string)
+	rootfsPath := ctx.App.Metadata["rootfs"].(string)
+
+	var meta UmociMeta
+	meta.Version = UmociMetaVersion
+
+	// Parse map options.
+	// We need to set mappings if we're in rootless mode.
+	err := parseIdmapOptions(&meta, ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get a reference to the CAS.
+	engine, err := dir.Open(imagePath)
+	if err != nil {
+		return errors.Wrap(err, "open CAS")
+	}
+	engineExt := casext.NewEngine(engine)
+	defer engine.Close()
+
+	fromDescriptorPaths, err := engineExt.ResolveReference(context.Background(), fromName)
+	if err != nil {
+		return errors.Wrap(err, "get descriptor")
+	}
+	if len(fromDescriptorPaths) == 0 {
+		return errors.Errorf("tag is not found: %s", fromName)
+	}
+	if len(fromDescriptorPaths) != 1 {
+		// TODO: Handle this more nicely.
+		return errors.Errorf("tag is ambiguous: %s", fromName)
+	}
+	meta.From = fromDescriptorPaths[0]
+
+	manifestBlob, err := engineExt.FromDescriptor(context.Background(), meta.From.Descriptor())
+	if err != nil {
+		return errors.Wrap(err, "get manifest")
+	}
+	defer manifestBlob.Close()
+
+	if manifestBlob.MediaType != ispec.MediaTypeImageManifest {
+		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.MediaType), "invalid --image tag")
+	}
+
+	log.WithFields(log.Fields{
+		"image":  imagePath,
+		"rootfs": rootfsPath,
+		"ref":    fromName,
+	}).Debugf("umoci: unpacking OCI image")
+
+	// Get the manifest.
+	manifest, ok := manifestBlob.Data.(ispec.Manifest)
+	if !ok {
+		// Should _never_ be reached.
+		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
+	}
+
+	// FIXME: Currently we only support OCI layouts, not tar archives. This
+	//        should be fixed once the CAS engine PR is merged into
+	//        image-tools. https://github.com/opencontainers/image-tools/pull/5
+	log.Warnf("unpacking rootfs ...")
+	if err := layer.UnpackRootfs(context.Background(), engineExt, rootfsPath, manifest, &meta.MapOptions); err != nil {
+		return errors.Wrap(err, "create rootfs")
+	}
+	log.Warnf("... done")
+
+	log.Warnf("unpacked image rootfs: %s", rootfsPath)
+	return nil
+}

--- a/cmd/umoci/raw.go
+++ b/cmd/umoci/raw.go
@@ -34,5 +34,6 @@ should be sufficient for most use-cases.`,
 
 	Subcommands: []cli.Command{
 		rawConfigCommand,
+		rawUnpackCommand,
 	},
 }

--- a/doc/man/umoci-raw-unpack.1.md
+++ b/doc/man/umoci-raw-unpack.1.md
@@ -1,0 +1,70 @@
+% umoci-raw-unpack(1) # umoci raw unpack - Unpacks an OCI image tag into a root filesystem
+% Aleksa Sarai
+% APRIL 2018
+# NAME
+umoci raw unpack - Unpacks an OCI image tag into a root filesystem
+
+# SYNOPSIS
+**umoci raw unpack**
+**--image**=*image*[:*tag*]
+*rootfs*
+
+# DESCRIPTION
+Extracts all of the layers (deterministically) to a root filesystem at path
+*rootfs*. This path must not already exist.
+
+# OPTIONS
+The global options are defined in **umoci**(1).
+
+**--image**=*image*[:*tag*]
+  The OCI image tag which will be extracted to the *rootfs*. *image* must be a
+  path to a valid OCI image and *tag* must be a valid tag in the image. If
+  *tag* is not provided it defaults to "latest".
+
+**--uid-map**=[*value*]
+  Specifies a UID mapping to use while unpacking layers. This is used in a
+  similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
+
+**--gid-map**=[*value*]
+  Specifies a GID mapping to use while unpacking layers. This is used in a
+  similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
+
+**--rootless**
+  Enable rootless unpacking support. This allows for **umoci-raw-unpack**(1) to
+  be used as an unprivileged user. Use of this flag implies **--uid-map=0:$(id
+  -u):1** and **--gid-map=0:$(id -g):1**, as well as enabling several features
+  to fake parts of the unpacking in the attempt to generate an
+  as-close-as-possible extraction of the filesystem. Note that it is almost
+  always not possible to perfectly extract an OCI image with **--rootless**,
+  but it will be as close as possible.
+
+# EXAMPLE
+The following downloads an image from a **docker**(1) registry using
+**skopeo**(1), unpacks said image to a root filesystem, generates an OCI
+runtime configuration file with **umoci-raw-runtime-config**(1) and then
+creates a new container with **runc**(8).
+
+```
+% skopeo copy docker://opensuse/amd64:42.2 oci:image:latest
+# umoci raw unpack --image image rootfs
+# umoci raw runtime-config --image image --rootfs rootfs config.json
+# runc run ctr
+[ container session ]
+```
+
+With **--rootless** it is also possible to do the above example without root
+privileges. **umoci** will generate a configuration that works with rootless
+containers in **runc**(8).
+
+```
+% skopeo copy docker://opensuse/amd64:42.2 oci:image:latest
+% umoci raw unpack --image image --rootless rootfs
+% umoci raw runtime-config --image image --rootfs rootfs --rootless config.json
+% runc --root $HOME/runc run ctr
+[ rootless container session ]
+```
+
+# SEE ALSO
+**umoci**(1), **umoci-raw-runtime-config**(1), **runc**(8)

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -208,7 +208,7 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 	}
 	defer configBlob.Close()
 	if configBlob.MediaType != ispec.MediaTypeImageConfig {
-		return errors.Errorf("unpack manifest: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.MediaType)
+		return errors.Errorf("unpack rootfs: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.MediaType)
 	}
 	config, ok := configBlob.Data.(ispec.Image)
 	if !ok {
@@ -218,7 +218,7 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 
 	// We can't understand non-layer images.
 	if config.RootFS.Type != "layers" {
-		return errors.Errorf("unpack manifest: config: unsupported rootfs.type: %s", config.RootFS.Type)
+		return errors.Errorf("unpack rootfs: config: unsupported rootfs.type: %s", config.RootFS.Type)
 	}
 
 	// Layer extraction.
@@ -232,7 +232,7 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		}
 		defer layerBlob.Close()
 		if !isLayerType(layerBlob.MediaType) {
-			return errors.Errorf("unpack manifest: layer %s: blob is not correct mediatype: %s", layerBlob.Digest, layerBlob.MediaType)
+			return errors.Errorf("unpack rootfs: layer %s: blob is not correct mediatype: %s", layerBlob.Digest, layerBlob.MediaType)
 		}
 		layerData, ok := layerBlob.Data.(io.ReadCloser)
 		if !ok {

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -75,6 +75,11 @@ function umoci() {
 		args+=("__DEVEL--i-heard-you-like-tests")
 	fi
 
+	if [[ "$1" == "raw" ]]; then
+	    args+=("$1")
+	    shift 1
+	fi
+
 	# Set the first argument (the subcommand).
 	args+=("$1")
 

--- a/test/raw-unpack.bats
+++ b/test/raw-unpack.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2018 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci raw unpack" {
+        # It's actually not a bundle, but it's simpler to match the format of the unpack tests.
+	BUNDLE="$(setup_tmpdir)"
+
+	image-verify "${IMAGE}"
+
+	# Unpack the image.
+	umoci raw unpack --image "${IMAGE}:${TAG}" "$BUNDLE/rootfs"
+	[ "$status" -eq 0 ]
+
+	# We need to make sure these files *do not* exist.
+	! [ -f "$BUNDLE/config.json" ]
+	! [ -d "$BUNDLE/rootfs" ]
+
+	# Check that the image appears about right.
+	# NOTE: Since we could be using different images, this will be fairly
+	#       generic.
+	[ -e "$BUNDLE/rootfs/bin/sh" ]
+	[ -e "$BUNDLE/rootfs/etc/passwd" ]
+	[ -e "$BUNDLE/rootfs/etc/group" ]
+
+	image-verify "${IMAGE}"
+}
+
+@test "umoci raw unpack [missing args]" {
+	ROOTFS="$(setup_tmpdir)"
+
+	umoci raw unpack --image="${IMAGE}:${TAG}"
+	[ "$status" -ne 0 ]
+
+	umoci raw unpack "$BUNDLE/rootfs"
+	[ "$status" -ne 0 ]
+}
+
+@test "umoci raw unpack [too many args]" {
+	umoci raw unpack --image "${IMAGE}:${TAG}" too many arguments
+	[ "$status" -ne 0 ]
+	! [ -d too ]
+	! [ -d many ]
+	! [ -d arguments ]
+}
+
+@test "umoci raw unpack [cross-check with umoci unpack]" {
+	BUNDLE_A="$(setup_tmpdir)"
+	BUNDLE_B="$(setup_tmpdir)"
+
+	image-verify "${IMAGE}"
+
+	# Unpack the bundle
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE_A"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE_A"
+
+	# Unpack the rootfs
+	umoci raw unpack --image "${IMAGE}:${TAG}" "$BUNDLE_B/rootfs"
+	[ "$status" -eq 0 ]
+
+	# Ensure that gomtree suceeds on the new unpacked rootfs.
+	gomtree -p "$BUNDLE_B/rootfs" -f "$BUNDLE_A"/sha256_*.mtree
+	[ "$status" -eq 0 ]
+	[ -z "$output" ]
+
+	image-verify "${IMAGE}"
+}


### PR DESCRIPTION
This is pretty basic, and duplicates quite some code with the existing `unpack` code, that's why I've tagged this as WIP, to get the ball going and discuss our options.

I would like this feature for cases where we only care about getting the final rootfs. Computation of the mtree file can take a significant amount of time on large images (because of all the checksums that need to be computed).

thoughts @cyphar?

Closes #23