### PR TITLE
test: force removal to fix Travis CI failure

### DIFF
--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -159,7 +159,7 @@ function teardown_tmpdirs() {
 	done < "$TESTDIR_LIST"
 
 	# Clear tmpdir list.
-	rm "$TESTDIR_LIST"
+	rm -f "$TESTDIR_LIST"
 }
 
 # _getfattr is a sane wrapper around getfattr(1) which only extracts the value

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -131,8 +131,8 @@ function teardown() {
 
 	# Remove them.
 	chmod +w "$BUNDLE_A/rootfs/etc/." && rm -rf "$BUNDLE_A/rootfs/etc"
-	chmod +w "$BUNDLE_A/rootfs/bin/." && rm "$BUNDLE_A/rootfs/bin/sh"
-	chmod +w "$BUNDLE_A/rootfs/usr/bin/." && rm "$BUNDLE_A/rootfs/usr/bin/env"
+	chmod +w "$BUNDLE_A/rootfs/bin/." && rm -f "$BUNDLE_A/rootfs/bin/sh"
+	chmod +w "$BUNDLE_A/rootfs/usr/bin/." && rm -f "$BUNDLE_A/rootfs/usr/bin/env"
 
 	# Repack the image under a new tag.
 	umoci repack --image "${IMAGE}:${TAG}-new" "$BUNDLE_A"
@@ -198,9 +198,9 @@ function teardown() {
 	# Replace them.
 	chmod +w "$BUNDLE_A/rootfs/etc/." && rm -rf "$BUNDLE_A/rootfs/etc"
 	echo "different" > "$BUNDLE_A/rootfs/etc"
-	chmod +w "$BUNDLE_A/rootfs/bin/." && rm "$BUNDLE_A/rootfs/bin/sh"
+	chmod +w "$BUNDLE_A/rootfs/bin/." && rm -f "$BUNDLE_A/rootfs/bin/sh"
 	mkdir "$BUNDLE_A/rootfs/bin/sh"
-	chmod +w "$BUNDLE_A/rootfs/usr/bin/." && rm "$BUNDLE_A/rootfs/usr/bin/env"
+	chmod +w "$BUNDLE_A/rootfs/usr/bin/." && rm -f "$BUNDLE_A/rootfs/usr/bin/env"
 	ln -s "a \\really //weird _00..:=path " "$BUNDLE_A/rootfs/usr/bin/env"
 
 	# Repack the image under the same tag.
@@ -562,7 +562,7 @@ function teardown() {
 	[ -f "$BUNDLE_B/rootfs/ <-- some more weird characters --> 你好，世界" ]
 
 	# Now make some changes.
-	rm "$BUNDLE_B/rootfs/AC_Raíz_Certicámara_S.A..pem"
+	rm -f "$BUNDLE_B/rootfs/AC_Raíz_Certicámara_S.A..pem"
 
 	# Repack the image.
 	umoci repack --image "${IMAGE}" "$BUNDLE_B"


### PR DESCRIPTION
Apparenty Fedora has made some of their binaries unwriteable for all
users, which results in the rootless tests failing with strange errors:

    not ok 60 umoci repack [replace]
    # rm: remove write-protected regular file '/tmp/umoci-integration-tmpdir.8q2KHYm5/rootfs/usr/bin/env'?
    # ln: failed to create symbolic link '/tmp/umoci-integration-tmpdir.8q2KHYm5/rootfs/usr/bin/env': File exists

Fix this by just forcing removal everywhere in the tests.

Signed-off-by: Aleksa Sarai <asarai@suse.de>