### PR TITLE
*: add cisco copyright line in new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ umoci is licensed under the terms of the Apache 2.0 license.
 ```
 umoci: Umoci Modifies Open Containers' Images
 Copyright (C) 2016, 2017, 2018 SUSE LLC.
+Copyright (C) 2018 Cisco Systems
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api.go
+++ b/api.go
@@ -1,3 +1,20 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 Cisco Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package umoci
 
 import (

--- a/api_test.go
+++ b/api_test.go
@@ -1,3 +1,20 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 Cisco Systems
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package umoci
 
 import (


### PR DESCRIPTION
They were missing and it's probably a good idea to include them, purely
to make legal review less of a pain.

/cc @tych0 
Signed-off-by: Aleksa Sarai <asarai@suse.de>