### PR TITLE
cmd: add 'umoci raw add-layer'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,8 @@ RUN zypper -n in \
 		oci-image-tools \
 		oci-runtime-tools \
 		python-setuptools python-xattr attr \
-		skopeo
+		skopeo \
+		tar
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH

--- a/cmd/umoci/raw.go
+++ b/cmd/umoci/raw.go
@@ -33,6 +33,7 @@ of the OCI specifications. The top-level umoci-unpack(1) and similar commands
 should be sufficient for most use-cases.`,
 
 	Subcommands: []cli.Command{
+		rawAddLayerCommand,
 		rawConfigCommand,
 		rawUnpackCommand,
 	},

--- a/doc/man/umoci-insert.1.md
+++ b/doc/man/umoci-insert.1.md
@@ -1,0 +1,89 @@
+% umoci-insert(1) # umoci insert - insert a file into an OCI image
+% Aleksa Sarai
+% SEPTEMBER 2018
+# NAME
+umoci insert - insert a file into an OCI image
+
+# SYNOPSIS
+**umoci insert**
+**--image**=*image*[:*tag*]
+[**--rootless**]
+[**--uid-map**=*value*]
+[**--uid-map**=*value*]
+[**--history.comment**=*comment*]
+[**--history.created_by**=*created_by*]
+[**--history.author**=*author*]
+[**--history-created**=*date*]
+*file*
+*path*
+
+# DESCRIPTION
+Creates a new OCI image layout. The new OCI image does not contain any new
+references or blobs, but those can be created through the use of
+**umoci-new**(1), **umoci-tag**(1), **umoci-repack**(1) and other similar
+commands.
+
+Inserts *file* into the OCI image given by **--image** (overwriting it),
+creating a new layer containing just the contents of *file* at *path*. *file*
+can be a file or a directory to insert (in the latter case the directory is
+always recursed), and *path* is the full path where *file* will be inserted.
+
+# OPTIONS
+The global options are defined in **umoci**(1).
+
+**--image**=*image*[:*tag*]
+  The source and destination tag for the insertion of *file* at *path* inside
+  the container image. *image* must be a path to a valid OCI image and *tag*
+  must be a valid tag in the image. If *tag* is not provided it defaults to
+  "latest".
+
+**--rootless**
+  Enable rootless insertion support. This allows for **umoci-insert**(1) to be
+  used as an unprivileged user. Use of this flag implies **--uid-map=0:$(id
+  -u):1** and **--gid-map=0:$(id -g):1**, as well as enabling several features
+  to fake parts of the recursion process in an attempt to generate an
+  as-close-as-possible clone of the filesystem for insertion.
+
+**--uid-map**=*value*
+  Specifies a UID mapping to use when inserting files. This is used in a
+  similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
+
+**--gid-map**=*value*
+  Specifies a GID mapping to use when inserting files. This is used in a
+  similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
+
+**--history.comment**=*comment*
+  Comment for the history entry corresponding to this modification of the image
+  If unspecified, **umoci**(1) will generate an implementation-dependent value.
+
+**--history.created_by**=*created_by*
+  CreatedBy entry for the history entry corresponding to this modification of
+  the image. If unspecified, **umoci**(1) will generate an
+  implementation-dependent value.
+
+**--history.author**=*author*
+  Author value for the history entry corresponding to this modification of the
+  image. If unspecified, this value will be the image's author value **after**
+  any modifications were made by this call of **umoci-config**(1).
+
+**--history-created**=*date*
+  Creation date for the history entry corresponding to this modifications of
+  the image. This must be an ISO8601 formatted timestamp (see **date**(1)). If
+  unspecified, the current time is used.
+
+# EXAMPLE
+
+The following inserts a file `mybinary` into the path `/usr/bin/mybinary` and a
+directory `myconfigdir` into the path `/etc/myconfigdir`. It should be noted
+that if `/etc/myconfigdir` already exists in the image, the contents of the two
+directories are merged (with the newer layer taking precedence).
+
+```
+% umoci insert --image oci:foo mybinary /usr/bin/mybinary
+% umoci insert --image oci:foo myconfigdir /etc/myconfigdir
+```
+
+# SEE ALSO
+**umoci**(1), **umoci-repack**(1), **umoci-raw-add-layer**(1)

--- a/doc/man/umoci-raw-add-layer.1.md
+++ b/doc/man/umoci-raw-add-layer.1.md
@@ -1,0 +1,72 @@
+% umoci-raw-add-layer(1) # umoci raw add-layer - add a layer archive verbatim to an image
+% Aleksa Sarai
+% SEPTEMBER 2018
+# NAME
+umoci raw add-layer - add a layer archive verbatim to an image
+
+# SYNOPSIS
+**umoci raw add-layer**
+**--image**=*image*
+[**--tag**=*tag*]
+[**--history.comment**=*comment*]
+[**--history.created_by**=*created_by*]
+[**--history.author**=*author*]
+[**--history-created**=*date*]
+*new-layer.tar*
+
+# DESCRIPTION
+Adds the uncompressed layer archive referenced by *new-layer.tar* verbatim to
+the image. Note that since this is done verbatim, no changes are made to the
+layer and thus any OCI-specific `tar` extensions (such as `.wh.` whiteout
+files) will be included unmodified. Use of this command is therefore only
+recommended for expert users, and more novice users should look at
+**umoci-repack**(1) to create their layers.
+
+At the moment, **umoci raw add-layer** only supports appending layers to the
+end of the image layer list.
+
+# OPTIONS
+The global options are defined in **umoci**(1).
+
+**--image**=*image*[:*tag*]
+  The source tag to use as the base of the image containing the new layer.
+  *image* must be a path to a valid OCI image and *tag* must be a valid tag in
+  the image. If *tag* is not provided it defaults to "latest".
+
+**--tag**=*tag*
+  The destination tag to use for the newly created image. *tag* must be a valid
+  tag in the image. If *tag* is not provided it defaults to the *tag* specified
+  in **--image** (overwriting it).
+
+**--history.comment**=*comment*
+  Comment for the history entry corresponding to this modification of the image
+  If unspecified, **umoci**(1) will generate an implementation-dependent value.
+
+**--history.created_by**=*created_by*
+  CreatedBy entry for the history entry corresponding to this modification of
+  the image. If unspecified, **umoci**(1) will generate an
+  implementation-dependent value.
+
+**--history.author**=*author*
+  Author value for the history entry corresponding to this modification of the
+  image. If unspecified, this value will be the image's author value **after**
+  any modifications were made by this call of **umoci-config**(1).
+
+**--history-created**=*date*
+  Creation date for the history entry corresponding to this modifications of
+  the image. This must be an ISO8601 formatted timestamp (see **date**(1)). If
+  unspecified, the current time is used.
+
+# EXAMPLE
+
+The following takes an existing diff directory, creates a new archive from it
+and then inserts it into an existing image. Note that the new archive is *not*
+compressed (**umoci** will compress the archive for you).
+
+```
+% tar cfC diff-layer.tar diff/ .
+% umoci raw add-layer --image oci:foo diff-layer.tar
+```
+
+# SEE ALSO
+**umoci**(1), **umoci-repack**(1)

--- a/doc/man/umoci-unpack.1.md
+++ b/doc/man/umoci-unpack.1.md
@@ -7,7 +7,10 @@ umoci unpack - Unpacks an OCI image tag into an runtime bundle
 # SYNOPSIS
 **umoci unpack**
 **--image**=*image*[:*tag*]
-**--keep-dirlinks**
+[**--rootless**]
+[**--uid-map**=*value*]
+[**--uid-map**=*value*]
+[**--keep-dirlinks**]
 *bundle*
 
 # DESCRIPTION
@@ -26,24 +29,24 @@ The global options are defined in **umoci**(1).
   path to a valid OCI image and *tag* must be a valid tag in the image. If
   *tag* is not provided it defaults to "latest".
 
-**--uid-map**=[*value*]
-  Specifies a UID mapping to use while unpacking layers. This is used in a
-  similar fashion to **user_namespaces**(7), and is of the form
-  **container:host[:size]**.
-
-**--gid-map**=[*value*]
-  Specifies a GID mapping to use while unpacking layers. This is used in a
-  similar fashion to **user_namespaces**(7), and is of the form
-  **container:host[:size]**.
-
 **--rootless**
   Enable rootless unpacking support. This allows for **umoci-unpack**(1) and
   **umoci-repack**(1) to be used as an unprivileged user. Use of this flag
   implies **--uid-map=0:$(id -u):1** and **--gid-map=0:$(id -g):1**, as well as
-  enabling several features to fake parts of the unpacking in the attempt to
+  enabling several features to fake parts of the unpacking in an attempt to
   generate an as-close-as-possible extraction of the filesystem. Note that it
   is almost always not possible to perfectly extract an OCI image with
   **--rootless**, but it will be as close as possible.
+
+**--uid-map**=*value*
+  Specifies a UID mapping to use while unpacking (and repacking) layers. This
+  is used in a similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
+
+**--gid-map**=*value*
+  Specifies a GID mapping to use while unpacking (and repacking) layers. This
+  is used in a similar fashion to **user_namespaces**(7), and is of the form
+  **container:host[:size]**.
 
 **--keep-dirlinks**
   Instead of overwriting directories which are links to other directories when

--- a/oci/layer/utils.go
+++ b/oci/layer/utils.go
@@ -42,7 +42,7 @@ type MapOptions struct {
 	Rootless bool `json:"rootless"`
 
 	// KeepDirlinks is essentially the same as rsync's optio
-	// --keep-dirlinks: if, on extraction, a directroy would be created
+	// --keep-dirlinks: if, on extraction, a directory would be created
 	// where a symlink to a directory previously existed, KeepDirlinks
 	// doesn't create that directory, but instead just uses the existing
 	// symlink.
@@ -213,4 +213,21 @@ func CleanPath(path string) string {
 
 	// Clean the path again for good measure.
 	return filepath.Clean(path)
+}
+
+// InnerErrno returns the "real" system error from an error that originally
+// came from the "os" package. The returned error can be compared directly with
+// unix.* (or syscall.*) errno values. If the type could not be detected we just return
+func InnerErrno(err error) error {
+	// All of the os.* cases as well as an explicit
+	errno := errors.Cause(err)
+	switch err := errno.(type) {
+	case *os.PathError:
+		errno = err.Err
+	case *os.LinkError:
+		errno = err.Err
+	case *os.SyscallError:
+		errno = err.Err
+	}
+	return errno
 }

--- a/test/create.bats
+++ b/test/create.bats
@@ -71,11 +71,8 @@ function teardown() {
 }
 
 @test "umoci new --image" {
-	BUNDLE="$(setup_tmpdir)"
-
 	# Setup up $NEWIMAGE.
-	NEWIMAGE="$(setup_tmpdir)"
-	rm -rf "$NEWIMAGE"
+	NEWIMAGE="$(setup_tmpdir)/image"
 
 	# Create a new image with no tags.
 	umoci init --layout "$NEWIMAGE"
@@ -95,12 +92,13 @@ function teardown() {
 	#image-verify "$NEWIMAGE"
 
 	# Unpack the image.
+	new_bundle_rootfs
 	umoci unpack --image "${NEWIMAGE}" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
 	# Make sure that the rootfs is empty.
-	sane_run find "$BUNDLE/rootfs"
+	sane_run find "$ROOTFS"
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 1 ]
 

--- a/test/gc.bats
+++ b/test/gc.bats
@@ -31,8 +31,6 @@ function teardown() {
 }
 
 @test "umoci gc [consistent]" {
-	image-verify "${IMAGE}"
-
 	# Initial gc.
 	umoci gc --layout "${IMAGE}"
 	[ "$status" -eq 0 ]
@@ -57,10 +55,6 @@ function teardown() {
 }
 
 @test "umoci gc" {
-	BUNDLE="$(setup_tmpdir)"
-
-	image-verify "${IMAGE}"
-
 	# Initial gc.
 	umoci gc --layout "${IMAGE}"
 	[ "$status" -eq 0 ]
@@ -72,13 +66,14 @@ function teardown() {
 	nblobs="${#lines[@]}"
 
 	# Unpack the image.
+	new_bundle_rootfs
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
 	# Change the rootfs. We need to chmod because of fedora.
-	chmod +w "$BUNDLE/rootfs/usr/bin/." && rm -rf "$BUNDLE/rootfs/usr/bin"
-	chmod +w "$BUNDLE/rootfs/etc/." && rm -rf "$BUNDLE/rootfs/etc"
+	chmod +w "$ROOTFS/usr/bin/." && rm -rf "$ROOTFS/usr/bin"
+	chmod +w "$ROOTFS/etc/." && rm -rf "$ROOTFS/etc"
 
 	# Repack the image under a new tag.
 	umoci repack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
@@ -120,8 +115,6 @@ function teardown() {
 }
 
 @test "umoci gc [empty]" {
-	image-verify "${IMAGE}"
-
 	# Initial gc.
 	umoci gc --layout "${IMAGE}"
 	[ "$status" -eq 0 ]
@@ -158,8 +151,6 @@ function teardown() {
 }
 
 @test "umoci gc [internal]" {
-	image-verify "${IMAGE}"
-
 	# Initial gc.
 	umoci gc --layout "${IMAGE}"
 	[ "$status" -eq 0 ]

--- a/test/help.bats
+++ b/test/help.bats
@@ -49,7 +49,6 @@ load helpers
 }
 
 @test "umoci command --help" {
-
 	umoci config --help
 	[ "$status" -eq 0 ]
 	[[ "${lines[1]}" =~ "umoci config"+ ]]

--- a/test/helpers.bash
+++ b/test/helpers.bash
@@ -76,8 +76,8 @@ function umoci() {
 	fi
 
 	if [[ "$1" == "raw" ]]; then
-	    args+=("$1")
-	    shift 1
+		args+=("$1")
+		shift 1
 	fi
 
 	# Set the first argument (the subcommand).
@@ -133,6 +133,7 @@ function setup_image() {
 	cp -r "${SOURCE_IMAGE}" "${IMAGE}"
 	df >/dev/stderr
 	du -h -d 2 "$BATS_TMPDIR" >/dev/stderr
+	image-verify "${IMAGE}"
 }
 
 function teardown_image() {
@@ -165,6 +166,12 @@ function teardown_tmpdirs() {
 
 	# Clear tmpdir list.
 	rm -f "$TESTDIR_LIST"
+}
+
+# Generate a new $BUNDLE and $ROOTFS combination.
+function new_bundle_rootfs() {
+	declare -g BUNDLE="$(setup_tmpdir)"
+	declare -g ROOTFS="$BUNDLE/rootfs"
 }
 
 # _getfattr is a sane wrapper around getfattr(1) which only extracts the value

--- a/test/pack_mapping.bats
+++ b/test/pack_mapping.bats
@@ -29,21 +29,17 @@ function teardown() {
 	# We do a bunch of remapping tricks, which we can't really do if we're not root.
 	requires root
 
-	image-verify "${IMAGE}"
-
-	BUNDLE_A="$(setup_tmpdir)"
-	BUNDLE_B="$(setup_tmpdir)"
-
 	# Unpack the image.
-	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:1337:65535" --gid-map "0:8888:65535" "$BUNDLE_A"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:1337:65535" --gid-map "0:8888:65535" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_A"
+	bundle-verify "$BUNDLE"
 
 	# We need to make sure the config exists.
-	[ -f "$BUNDLE_A/config.json" ]
+	[ -f "$BUNDLE/config.json" ]
 
 	# Check that all of the files have a UID owner >=1337 and a GID owner >=8888.
-	find "$BUNDLE_A/rootfs" | xargs stat -c '%u:%g' | awk -F: '{
+	find "$ROOTFS" | xargs stat -c '%u:%g' | awk -F: '{
 		uid = $1;
 		if (uid < 1337 || uid >= 1337 + 65535)
 			exit 1;
@@ -53,15 +49,16 @@ function teardown() {
 	}'
 
 	# Unpack the image with a differen uid and gid mapping.
-	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:8080:65535" --gid-map "0:7777:65535" "$BUNDLE_B"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:8080:65535" --gid-map "0:7777:65535" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_B"
+	bundle-verify "$BUNDLE"
 
 	# We need to make sure the config exists.
-	[ -f "$BUNDLE_B/config.json" ]
+	[ -f "$BUNDLE/config.json" ]
 
 	# Check that all of the files have a UID owner >=8080 and a GID owner >=7777.
-	find "$BUNDLE_B/rootfs" | xargs stat -c '%u:%g' | awk -F: '{
+	find "$ROOTFS" | xargs stat -c '%u:%g' | awk -F: '{
 		uid = $1;
 		if (uid < 8080 || uid >= 8080 + 65535)
 			exit 1;
@@ -77,46 +74,43 @@ function teardown() {
 	# We do a bunch of remapping tricks, which we can't really do if we're not root.
 	requires root
 
-	image-verify "${IMAGE}"
-
-	BUNDLE_A="$(setup_tmpdir)"
-	BUNDLE_B="$(setup_tmpdir)"
-	BUNDLE_C="$(setup_tmpdir)"
-
 	# Unpack the image.
-	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:1337:65535" --gid-map "0:7331:65535" "$BUNDLE_A"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" --uid-map "0:1337:65535" --gid-map "0:7331:65535" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_A"
+	bundle-verify "$BUNDLE"
 
 	# We need to make sure the config exists.
-	[ -f "$BUNDLE_A/config.json" ]
+	[ -f "$BUNDLE/config.json" ]
 
 	# Create a new file with a remapped owner.
-	echo "new file" > "$BUNDLE_A/rootfs/new test file "
-	chown "2000:8000" "$BUNDLE_A/rootfs/new test file "
+	echo "new file" > "$ROOTFS/new test file "
+	chown "2000:8000" "$ROOTFS/new test file "
 
 	# Repack the image using the same mapping.
-	umoci repack --image "${IMAGE}:${TAG}-new" "$BUNDLE_A"
+	umoci repack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
 	# Unpack it again with a different mapping.
-	umoci unpack --image "${IMAGE}:${TAG}-new" --uid-map "0:4000:65535" --gid-map "0:4000:65535" "$BUNDLE_B"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}-new" --uid-map "0:4000:65535" --gid-map "0:4000:65535" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_B"
+	bundle-verify "$BUNDLE"
 
 	# Make sure that the test file is different.
-	sane_run stat -c '%u:%g' "$BUNDLE_B/rootfs/new test file "
+	sane_run stat -c '%u:%g' "$ROOTFS/new test file "
 	[ "$status" -eq 0 ]
 	[[ "$output" == "$((2000 - 1337 + 4000)):$((8000 - 7331 + 4000))" ]]
 
 	# Redo the unpacking with no mapping.
-	umoci unpack --image "${IMAGE}:${TAG}-new" "$BUNDLE_C"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_C"
+	bundle-verify "$BUNDLE"
 
 	# Make sure that the test file was unpacked properly.
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/new test file "
+	sane_run stat -c '%u:%g' "$ROOTFS/new test file "
 	[ "$status" -eq 0 ]
 	[[ "$output" == "$((2000 - 1337)):$((8000 - 7331))" ]]
 
@@ -127,108 +121,105 @@ function teardown() {
 	# While we forcefully use --rootless, we also change the owner of files.
 	requires root
 
-	image-verify "${IMAGE}"
-
-	BUNDLE_A="$(setup_tmpdir)"
-	BUNDLE_B="$(setup_tmpdir)"
-	BUNDLE_C="$(setup_tmpdir)"
-
 	# Root-ful unpack first to create non-root files.
-	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE_A"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_A"
+	bundle-verify "$BUNDLE"
 
 	# Create some files with non-root owners.
-	touch "$BUNDLE_A/rootfs/owner_a" && chown 992:123 "$BUNDLE_A/rootfs/owner_a"
-	touch "$BUNDLE_A/rootfs/owner_b" && chown   0:456 "$BUNDLE_A/rootfs/owner_b"
-	touch "$BUNDLE_A/rootfs/owner_c" && chown  98:0   "$BUNDLE_A/rootfs/owner_c"
-	touch "$BUNDLE_A/rootfs/owner_d" && chown 492:218 "$BUNDLE_A/rootfs/owner_d"
-	touch "$BUNDLE_A/rootfs/owner_e" && chown 123:456 "$BUNDLE_A/rootfs/owner_e"
+	touch "$ROOTFS/owner_a" && chown 992:123 "$ROOTFS/owner_a"
+	touch "$ROOTFS/owner_b" && chown   0:456 "$ROOTFS/owner_b"
+	touch "$ROOTFS/owner_c" && chown  98:0   "$ROOTFS/owner_c"
+	touch "$ROOTFS/owner_d" && chown 492:218 "$ROOTFS/owner_d"
+	touch "$ROOTFS/owner_e" && chown 123:456 "$ROOTFS/owner_e"
 
 	# Repack.
-	umoci repack --image "${IMAGE}:${TAG}" "$BUNDLE_A"
+	umoci repack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
 	# Rootless unpack to test user.rootlesscontainers.
-	umoci unpack --rootless --image "${IMAGE}:${TAG}" "$BUNDLE_B"
+	new_bundle_rootfs
+	umoci unpack --rootless --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_B"
+	bundle-verify "$BUNDLE"
 
 	# Now check that the owners are all the current owner.
-	[ -O "$BUNDLE_B/rootfs/owner_a" ] && [ -G "$BUNDLE_B/rootfs/owner_a" ]
-	[ -O "$BUNDLE_B/rootfs/owner_b" ] && [ -G "$BUNDLE_B/rootfs/owner_b" ]
-	[ -O "$BUNDLE_B/rootfs/owner_c" ] && [ -G "$BUNDLE_B/rootfs/owner_c" ]
-	[ -O "$BUNDLE_B/rootfs/owner_d" ] && [ -G "$BUNDLE_B/rootfs/owner_d" ]
-	[ -O "$BUNDLE_B/rootfs/owner_e" ] && [ -G "$BUNDLE_B/rootfs/owner_e" ]
+	[ -O "$ROOTFS/owner_a" ] && [ -G "$ROOTFS/owner_a" ]
+	[ -O "$ROOTFS/owner_b" ] && [ -G "$ROOTFS/owner_b" ]
+	[ -O "$ROOTFS/owner_c" ] && [ -G "$ROOTFS/owner_c" ]
+	[ -O "$ROOTFS/owner_d" ] && [ -G "$ROOTFS/owner_d" ]
+	[ -O "$ROOTFS/owner_e" ] && [ -G "$ROOTFS/owner_e" ]
 
 	# Check the "user.rootlesscontainers" values against known values (this may
 	# break if the rootlesscontainers.proto changes in the future -- so keep
 	# this in mind if the tests start failing).
 	# NOTE: We use getfattr(1) here rather than xattr(1) because getfattr(1)
-	#       actually can handle binary xattrs -- while xattr(1) just removes
-	#       the values.
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_B/rootfs/owner_a"
+	#	   actually can handle binary xattrs -- while xattr(1) just removes
+	#	   the values.
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_a"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0x08e007107b" ]] # 992:123
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_B/rootfs/owner_b"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_b"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0x08ffffffff0f10c803" ]] # noop:456
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_B/rootfs/owner_c"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_c"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0x086210ffffffff0f" ]] # 98:noop
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_B/rootfs/owner_d"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_d"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0x08ec0310da01" ]] # 492:218
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_B/rootfs/owner_e"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_e"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0x087b10c803" ]] # 123:456
 
 	# Changing it should affect the second unpack. This is a pre-computed value
 	# equal to "3195:2318" serialised as a protobuf payload.
-	setfattr -n "user.rootlesscontainers" -v "0x08fb18108e12" "$BUNDLE_B/rootfs/owner_d"
+	setfattr -n "user.rootlesscontainers" -v "0x08fb18108e12" "$ROOTFS/owner_d"
 	# Removing it should make it be owned by root.
-	setfattr -x "user.rootlesscontainers" "$BUNDLE_B/rootfs/owner_e"
+	setfattr -x "user.rootlesscontainers" "$ROOTFS/owner_e"
 
 	# Repack.
-	umoci repack --image "${IMAGE}:${TAG}" "$BUNDLE_B"
+	umoci repack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
 	# Root-ful unpack again to check the changes.
-	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE_C"
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
-	bundle-verify "$BUNDLE_C"
+	bundle-verify "$BUNDLE"
 
 	# Check the owners. a...c should be unchanged ...
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/owner_a"
+	sane_run stat -c '%u:%g' "$ROOTFS/owner_a"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "992:123" ]]
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/owner_b"
+	sane_run stat -c '%u:%g' "$ROOTFS/owner_b"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0:456" ]]
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/owner_c"
+	sane_run stat -c '%u:%g' "$ROOTFS/owner_c"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "98:0" ]]
 	# ... while d...e will be modified.
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/owner_d"
+	sane_run stat -c '%u:%g' "$ROOTFS/owner_d"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "3195:2318" ]]
-	sane_run stat -c '%u:%g' "$BUNDLE_C/rootfs/owner_e"
+	sane_run stat -c '%u:%g' "$ROOTFS/owner_e"
 	[ "$status" -eq 0 ]
 	[[ "$output" == "0:0" ]]
 
 	# Make sure we don't have any user.rootlesscontainers xattrs now (they
 	# shouldn't be exposed to users or added to the tar layers).
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_C/rootfs/owner_a"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_a"
 	[ "$status" -ne 0 ]
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_C/rootfs/owner_b"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_b"
 	[ "$status" -ne 0 ]
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_C/rootfs/owner_c"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_c"
 	[ "$status" -ne 0 ]
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_C/rootfs/owner_d"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_d"
 	[ "$status" -ne 0 ]
-	sane_run _getfattr user.rootlesscontainers "$BUNDLE_C/rootfs/owner_e"
+	sane_run _getfattr user.rootlesscontainers "$ROOTFS/owner_e"
 	[ "$status" -ne 0 ]
 
 	image-verify "${IMAGE}"

--- a/test/raw-add-layer.bats
+++ b/test/raw-add-layer.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2018 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci raw add-layer" {
+	image-verify "${IMAGE}"
+
+	LAYERS_DIR="$(setup_tmpdir)"
+
+	# Create layer1.
+	LAYER="$(setup_tmpdir)"
+	echo "layer1" > "$LAYER/file"
+	mkdir "$LAYER/dir1"
+	echo "layer1" > "$LAYER/dir1/file"
+	tar cvfC "$LAYERS_DIR/layer1.tar" "$LAYER" .
+
+	# Create layer2.
+	LAYER="$(setup_tmpdir)"
+	echo "layer2" > "$LAYER/file"
+	mkdir "$LAYER/dir2" "$LAYER/dir3"
+	echo "layer2" > "$LAYER/dir2/file"
+	echo "layer2" > "$LAYER/dir3/file"
+	tar cvfC "$LAYERS_DIR/layer2.tar" "$LAYER" .
+
+	# Create layer3.
+	LAYER="$(setup_tmpdir)"
+	echo "layer3" > "$LAYER/file"
+	mkdir "$LAYER/dir2"
+	echo "layer3" > "$LAYER/dir2/file"
+	tar cvfC "$LAYERS_DIR/layer3.tar" "$LAYER" .
+
+	# Add layers to the image.
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	#image-verify "${IMAGE}"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$LAYERS_DIR/layer1.tar"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$LAYERS_DIR/layer2.tar"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$LAYERS_DIR/layer3.tar"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Unpack the created image.
+	BUNDLE="$(setup_tmpdir)" && ROOTFS="$BUNDLE/rootfs"
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# Make sure the layers were extracted in-order.
+	sane_run cat "$ROOTFS/file"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"layer3"* ]]
+	sane_run cat "$ROOTFS/dir1/file"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"layer1"* ]]
+	sane_run cat "$ROOTFS/dir2/file"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"layer3"* ]]
+	sane_run cat "$ROOTFS/dir3/file"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"layer2"* ]]
+
+	image-verify "${IMAGE}"
+}
+
+@test "umoci raw add-layer [missing args]" {
+	DIR="$(setup_tmpdir)"
+
+	# Missing layer.
+	umoci raw add-layer --image="${IMAGE}:${TAG}"
+	[ "$status" -ne 0 ]
+
+	# Missing image.
+	touch "$DIR/file"
+	umoci raw add-layer "$DIR/file"
+	[ "$status" -ne 0 ]
+
+	# Using a directory as an image file.
+	umoci raw add-layer --image="${IMAGE}:${TAG}" "$DIR"
+	[ "$status" -ne 0 ]
+}
+
+@test "umoci raw add-layer [too many args]" {
+	DIR="$(setup_tmpdir)"
+	touch "$DIR/file"{1..3}
+
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$DIR/file"{1..3}
+	[ "$status" -ne 0 ]
+}

--- a/test/raw-unpack.bats
+++ b/test/raw-unpack.bats
@@ -26,22 +26,18 @@ function teardown() {
 }
 
 @test "umoci raw unpack" {
-        # It's actually not a bundle, but it's simpler to match the format of the unpack tests.
-	BUNDLE="$(setup_tmpdir)"
-
-	image-verify "${IMAGE}"
-
 	# Unpack the image.
-	umoci raw unpack --image "${IMAGE}:${TAG}" "$BUNDLE/rootfs"
+	new_bundle_rootfs
+	umoci raw unpack --image "${IMAGE}:${TAG}" "$ROOTFS"
 	[ "$status" -eq 0 ]
 
 	# We need to make sure these files *do not* exist.
 	! [ -f "$BUNDLE/config.json" ]
-	! [ -d "$BUNDLE/rootfs" ]
+	[ -d "$ROOTFS" ]
 
 	# Check that the image appears about right.
 	# NOTE: Since we could be using different images, this will be fairly
-	#       generic.
+	#	   generic.
 	[ -e "$BUNDLE/rootfs/bin/sh" ]
 	[ -e "$BUNDLE/rootfs/etc/passwd" ]
 	[ -e "$BUNDLE/rootfs/etc/group" ]
@@ -55,7 +51,7 @@ function teardown() {
 	umoci raw unpack --image="${IMAGE}:${TAG}"
 	[ "$status" -ne 0 ]
 
-	umoci raw unpack "$BUNDLE/rootfs"
+	umoci raw unpack "$ROOTFS"
 	[ "$status" -ne 0 ]
 }
 
@@ -68,22 +64,19 @@ function teardown() {
 }
 
 @test "umoci raw unpack [cross-check with umoci unpack]" {
-	BUNDLE_A="$(setup_tmpdir)"
-	BUNDLE_B="$(setup_tmpdir)"
-
-	image-verify "${IMAGE}"
-
 	# Unpack the bundle
+	BUNDLE_A="$(setup_tmpdir)"
 	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE_A"
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE_A"
 
 	# Unpack the rootfs
-	umoci raw unpack --image "${IMAGE}:${TAG}" "$BUNDLE_B/rootfs"
+	BUNDLE_B="$(setup_tmpdir)" && ROOTFS_B="$BUNDLE_B/rootfs"
+	umoci raw unpack --image "${IMAGE}:${TAG}" "$ROOTFS_B"
 	[ "$status" -eq 0 ]
 
 	# Ensure that gomtree suceeds on the new unpacked rootfs.
-	gomtree -p "$BUNDLE_B/rootfs" -f "$BUNDLE_A"/sha256_*.mtree
+	gomtree -p "$ROOTFS_B" -f "$BUNDLE_A"/sha256_*.mtree
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 

--- a/test/stat.bats
+++ b/test/stat.bats
@@ -26,8 +26,6 @@ function teardown() {
 }
 
 @test "umoci stat --json" {
-	image-verify "${IMAGE}"
-
 	# Make sure that stat looks about right.
 	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
@@ -50,8 +48,6 @@ function teardown() {
 
 # We can't really test the output for non-JSON output, but we can smoke test it.
 @test "umoci stat [smoke]" {
-	image-verify "${IMAGE}"
-
 	# Make sure that stat looks about right.
 	umoci stat --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
@@ -72,4 +68,4 @@ function teardown() {
 }
 
 # TODO: Add a test to make sure that empty_layer and layer are mutually
-#       exclusive. Unfortunately, jq doesn't provide an XOR operator...
+#	   exclusive. Unfortunately, jq doesn't provide an XOR operator...

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -26,8 +26,6 @@ function teardown() {
 }
 
 @test "umoci list" {
-	image-verify "${IMAGE}"
-
 	# Get list of tags.
 	umoci ls --layout "${IMAGE}"
 	[ "$status" -eq 0 ]

--- a/vendor.conf
+++ b/vendor.conf
@@ -9,7 +9,7 @@ github.com/opencontainers/runtime-tools v0.7.0
   github.com/syndtr/gocapability 33e07d32887e1e06b7c025f27ce52f62c7990bc0
 github.com/rootless-containers/proto v0.1.0
 github.com/urfave/cli v1.20.0
-github.com/cyphar/filepath-securejoin v0.2.1
+github.com/cyphar/filepath-securejoin v0.2.2
 github.com/vbatts/go-mtree 1bcf4de08ff771c9b288e3a25348f195d404c17b
   github.com/sirupsen/logrus v1.0.6
 github.com/docker/go-units v0.3.3

--- a/vendor/github.com/cyphar/filepath-securejoin/join.go
+++ b/vendor/github.com/cyphar/filepath-securejoin/join.go
@@ -12,7 +12,6 @@ package securejoin
 
 import (
 	"bytes"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -23,7 +22,7 @@ import (
 
 // ErrSymlinkLoop is returned by SecureJoinVFS when too many symlinks have been
 // evaluated in attempting to securely join the two given paths.
-var ErrSymlinkLoop = fmt.Errorf("SecureJoin: too many links")
+var ErrSymlinkLoop = errors.Wrap(syscall.ELOOP, "secure join")
 
 // IsNotExist tells you if err is an error that implies that either the path
 // accessed does not exist (or path components don't exist). This is


### PR DESCRIPTION
This is a very simple helper function that allows users to "BYO" layers
that were generated elsewhere. It should be noted that this does
slightly hardcode tar archives into umoci's interface more than I'd
like, but I'm sure we can work around that if we have to in the future.

In addition, this fixes the --keep-dirlinks tests to test all of the
important features (like nesting resolution as well as loop detection
and breakout).

/cc @tych0
Signed-off-by: Aleksa Sarai <asarai@suse.de>