### PR TITLE
*: various whiteout improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added `umoci unpack --keep-dirlinks` (in the same vein as rsync's flag with
   the same name) which allows layers that contain entries which have a symlink
   as a path component. openSUSE/umoci#246
+- `umoci insert` now supports whiteouts in two significant ways. You can use
+  `--whiteout` to "insert" a deletion of a given path, while you can use
+  `--opaque` to replace a directory by adding an opaque whiteout (the default
+  behaviour causes the old and new directories to be merged).
+  openSUSE/umoci#257
 
 ## Fixed
 - Docker has changed how they handle whiteouts for non-existent files. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   the same name) which allows layers that contain entries which have a symlink
   as a path component. openSUSE/umoci#246
 
+## Fixed
+- Docker has changed how they handle whiteouts for non-existent files. The
+  specification is loose on this (and in umoci we've always been liberal with
+  whiteout generation -- to avoid cases where someone was confused we didn't
+  have a whiteout for every entry). But now that they have deviated from the
+  spec, in the interest of playing nice, we can just follow their new
+  restriction (even though it is not supported by the spec). This also makes
+  our layers *slightly* smaller. openSUSE/umoci#254
+
 ## [0.4.1] - 2018-08-16
 ### Added
 - The number of possible tags that are now valid with `umoci` subcommands has

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -184,7 +184,9 @@ func repack(ctx *cli.Context) error {
 			maskedPaths = append(maskedPaths, v)
 		}
 	}
-	diffs = mtreefilter.FilterDeltas(diffs, mtreefilter.MaskFilter(maskedPaths))
+	diffs = mtreefilter.FilterDeltas(diffs,
+		mtreefilter.MaskFilter(maskedPaths),
+		mtreefilter.SimplifyFilter(diffs))
 
 	reader, err := layer.GenerateLayer(fullRootfsPath, diffs, &meta.MapOptions)
 	if err != nil {

--- a/pkg/mtreefilter/mask.go
+++ b/pkg/mtreefilter/mask.go
@@ -27,48 +27,74 @@ import (
 // FilterFunc is a function used when filtering deltas with FilterDeltas.
 type FilterFunc func(path string) bool
 
-// isParent returns whether the path a is lexically an ancestor of the path b.
-func isParent(a, b string) bool {
-	a = filepath.Clean(a)
-	b = filepath.Clean(b)
+// makeRoot does a very simple job of converting a path to a lexical
+// relative-to-root. In mtree we don't deal with any symlink components.
+func makeRoot(path string) string {
+	return filepath.Join(string(filepath.Separator), path)
+}
 
-	for a != b && b != filepath.Dir(b) {
-		b = filepath.Dir(b)
+func maskFilter(maskedPaths map[string]struct{}, includeSelf bool) FilterFunc {
+	return func(path string) bool {
+		// Convert the path to be cleaned and relative-to-root.
+		path = makeRoot(path)
+
+		// Check that no ancestor of the path is a masked path.
+		for parent := path; parent != filepath.Dir(parent); parent = filepath.Dir(parent) {
+			if _, ok := maskedPaths[parent]; !ok {
+				continue
+			}
+			if parent == path && !includeSelf {
+				continue
+			}
+			log.Debugf("maskfilter: ignoring path %q matched by mask %q", path, parent)
+			return false
+		}
+		return true
 	}
-	return a == b
 }
 
 // MaskFilter is a factory for FilterFuncs that will mask all InodeDelta paths
 // that are lexical children of any path in the mask slice. All paths are
 // considered to be relative to '/'.
 func MaskFilter(masks []string) FilterFunc {
-	return func(path string) bool {
-		// Convert the path to be cleaned and relative-to-root.
-		path = filepath.Join("/", path)
-
-		// Check that no masks are matched.
-		for _, mask := range masks {
-			// Mask also needs to be cleaned and relative-to-root.
-			mask = filepath.Join("/", mask)
-
-			// Is it a parent?
-			if isParent(mask, path) {
-				log.Debugf("maskfilter: ignoring path %q matched by mask %q", path, mask)
-				return false
-			}
-		}
-
-		return true
+	maskedPaths := map[string]struct{}{}
+	for _, mask := range masks {
+		maskedPaths[makeRoot(mask)] = struct{}{}
 	}
+	return maskFilter(maskedPaths, true)
+}
+
+// SimplifyFilter is a factory that takes a list of InodeDelta and creates a
+// filter to filter out all deletion entries that have a parent which also has
+// a deletion entry. This is necessary to both reduce our image sizes and
+// remain compatible with Docker's now-incompatible image format (the OCI spec
+// doesn't require this behaviour but it's now needed because of course Docker
+// won't fix their own bugs).
+func SimplifyFilter(deltas []mtree.InodeDelta) FilterFunc {
+	deletedPaths := make(map[string]struct{})
+	for _, delta := range deltas {
+		if delta.Type() != mtree.Missing {
+			continue
+		}
+		deletedPaths[makeRoot(delta.Path())] = struct{}{}
+	}
+	return maskFilter(deletedPaths, false)
 }
 
 // FilterDeltas is a helper function to easily filter []mtree.InodeDelta with a
 // filter function. Only entries which have `filter(delta.Path()) == true` will
 // be included in the returned slice.
-func FilterDeltas(deltas []mtree.InodeDelta, filter FilterFunc) []mtree.InodeDelta {
+func FilterDeltas(deltas []mtree.InodeDelta, filters ...FilterFunc) []mtree.InodeDelta {
 	var filtered []mtree.InodeDelta
 	for _, delta := range deltas {
-		if filter(delta.Path()) {
+		var blocked bool
+		for _, filter := range filters {
+			if !filter(delta.Path()) {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
 			filtered = append(filtered, delta)
 		}
 	}


### PR DESCRIPTION
Previously umoci-insert(1) was quite limited in that it would only
insert a given file or directory without having any configurability.
Something users might want is the ability to delete a path without an
unpack-repack cycle. Or they want to replace the contents of a directory
rather than merge them.

To this effect, add --whiteout and --opaque which provide the
corresponding features. --whiteout just adds a whiteout at the target
path, while --opaque adds an opaque whiteout for the target before doing
the copy.

In addition, add support for "simplified whiteouts". This change ultimately
makes our images a little bit smaller by no longer whiting-out every sub-entry
when a directory has been deleted.  While this is a net benefit, the cause of
this change is a Docker breakage (which arguably added a restriction that is
contrary to the OCI specification and thus it is definitely *their* bug). But
to play nice (and to take the opportunity to improve some images) we can fix it
in umoci.

Fixes #257 
Fixes #254 
Signed-off-by: Aleksa Sarai <asarai@suse.de>