### PR TITLE
umoci: make --rootless hint louder

### DIFF
--- a/cmd/umoci/main.go
+++ b/cmd/umoci/main.go
@@ -152,7 +152,7 @@ func main() {
 		// that --rootless might help. We probably should only be doing this if
 		// we're an unprivileged user.
 		if os.IsPermission(errors.Cause(err)) {
-			log.Info("umoci encountered a permission error: maybe --rootless will help?")
+			log.Warn("umoci encountered a permission error: maybe --rootless will help?")
 		}
 		log.Fatalf("%v", err)
 		log.Debugf("%+v", err)


### PR DESCRIPTION
We added a hint if a user got EPERM to use --rootless to try to fix it
in a9ebb42831ad ("cmd: give 'helpful' hint about --rootless"). However,
since then we changed the logging to be a bit less noisy and this patch
was lost in the changes -- so we need to make this a bit louder to make
sure it's visible by default.

Fixes #262 
Reported-by: Vincent Batts <vbatts@hashbangbash.com>
Signed-off-by: Aleksa Sarai <asarai@suse.de>