### PR TITLE
doc: site: updates to include more information

### DIFF
--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -1,7 +1,7 @@
 /*
  * umoci: Umoci Modifies Open Containers' Images
  * Copyright (C) 2016, 2017, 2018 SUSE LLC.
- * Copyright (C) 2018 Cisco
+ * Copyright (C) 2018 Cisco Systems
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/doc/man/umoci-raw-unpack.1.md
+++ b/doc/man/umoci-raw-unpack.1.md
@@ -1,50 +1,22 @@
 % umoci-raw-unpack(1) # umoci raw unpack - Unpacks an OCI image tag into a root filesystem
 % Aleksa Sarai
-% APRIL 2018
+% SEPTEMBER 2018
 # NAME
 umoci raw unpack - Unpacks an OCI image tag into a root filesystem
 
 # SYNOPSIS
 **umoci raw unpack**
-**--image**=*image*[:*tag*]
-**--keep-dirlinks**
+[*umoci-unpack(1) flags*]
 *rootfs*
 
 # DESCRIPTION
 Extracts all of the layers (deterministically) to a root filesystem at path
-*rootfs*. This path must not already exist.
+*rootfs*. This path *must not* already exist.
 
 # OPTIONS
-The global options are defined in **umoci**(1).
-
-**--image**=*image*[:*tag*]
-  The OCI image tag which will be extracted to the *rootfs*. *image* must be a
-  path to a valid OCI image and *tag* must be a valid tag in the image. If
-  *tag* is not provided it defaults to "latest".
-
-**--uid-map**=[*value*]
-  Specifies a UID mapping to use while unpacking layers. This is used in a
-  similar fashion to **user_namespaces**(7), and is of the form
-  **container:host[:size]**.
-
-**--gid-map**=[*value*]
-  Specifies a GID mapping to use while unpacking layers. This is used in a
-  similar fashion to **user_namespaces**(7), and is of the form
-  **container:host[:size]**.
-
-**--rootless**
-  Enable rootless unpacking support. This allows for **umoci-raw-unpack**(1) to
-  be used as an unprivileged user. Use of this flag implies **--uid-map=0:$(id
-  -u):1** and **--gid-map=0:$(id -g):1**, as well as enabling several features
-  to fake parts of the unpacking in the attempt to generate an
-  as-close-as-possible extraction of the filesystem. Note that it is almost
-  always not possible to perfectly extract an OCI image with **--rootless**,
-  but it will be as close as possible.
-
-**--keep-dirlinks**
-  Instead of overwriting directories which are links to other directories when
-  higher layers have an explicit directory, just write through the symlink.
-  This option is inspired by rsync's option of the same name.
+The global options are defined in **umoci**(1), while the options for this
+particular subcommand are identical to **umoci-unpack**(1) with the exception
+that the *rootfs* path is provided rather than a *bundle* path.
 
 # EXAMPLE
 The following downloads an image from a **docker**(1) registry using

--- a/doc/man/umoci-raw.1.md
+++ b/doc/man/umoci-raw.1.md
@@ -1,6 +1,6 @@
 % umoci-raw(1) # umoci raw - Advanced internal image tooling
 % Aleksa Sarai
-% APRIL 2017
+% SEPTEMBER 2018
 # NAME
 umoci raw - Advanced internal image tooling
 
@@ -23,4 +23,6 @@ tools (**umoci-unpack**(1) and so on) should be sufficient for most use-cases.
 
 # SEE ALSO
 **umoci**(1),
-**umoci-raw-runtime-config**(1)
+**umoci-raw-add-layer**(1),
+**umoci-raw-runtime-config**(1),
+**umoci-raw-unpack**(1)

--- a/doc/man/umoci-stat.1.md
+++ b/doc/man/umoci-stat.1.md
@@ -1,6 +1,6 @@
 % umoci-stat(1) # umoci stat - Display status information about an image tag
 % Aleksa Sarai
-% DECEMBER 2016
+% SEPTEMBER 2018
 # NAME
 umoci stat - Display status information about an image tag
 
@@ -13,10 +13,9 @@ umoci stat - Display status information about an image tag
 Generates various pieces of status information about an image tag, including
 the history of the image.
 
-**WARNING**: Do not depend on the output of this tool unless you are using the
-**--json** flag. The intention of the default formatting of this tool is to
-make it human-readable, and might change in future versions. For parseable
-and stable output, use **--json**.
+**WARNING**: Do not depend on the output of this tool. Previously we
+recommended the use of **--json** as the "stable" interface but this interface
+will be reworked in future.
 
 # OPTIONS
 The global options are defined in **umoci**(1).

--- a/doc/man/umoci-unpack.1.md
+++ b/doc/man/umoci-unpack.1.md
@@ -1,6 +1,6 @@
 % umoci-unpack(1) # umoci unpack - Unpacks an OCI image tag into an runtime bundle
 % Aleksa Sarai
-% DECEMBER 2016
+% SEPTEMBER 2018
 # NAME
 umoci unpack - Unpacks an OCI image tag into an runtime bundle
 

--- a/doc/man/umoci.1.md
+++ b/doc/man/umoci.1.md
@@ -1,14 +1,15 @@
 % umoci(1) # umoci - umoci modifies Open Container images
 % Aleksa Sarai
-% DECEMBER 2016
+% SEPTEMBER 2018
 # NAME
 umoci - umoci modifies Open Container images
 
 # SYNOPSIS
 **umoci**
-[**--debug**]
 [**--help**|**-h**]
 [**--version**|**-v**]
+[**--log**={*debug*|*info*|*warn*|*error*|*fatal*}]
+[**--verbose**]
 *command* [*args*]
 
 # DESCRIPTION
@@ -30,8 +31,11 @@ doing a high-level operation such as **umoci-repack**(1)).
 **--version, -v**
   Print the version.
 
-**--debug**
-  Output debugging information.
+**--log**={*debug*|*info*|*warn*|*error*|*fatal*}
+  Set the logging level. The default is "warn".
+
+**--verbose**
+  Alias for **--log=info**.
 
 # COMMANDS
 

--- a/doc/site/advanced/workflow-optimisation.md
+++ b/doc/site/advanced/workflow-optimisation.md
@@ -99,3 +99,93 @@ Internally, `--refresh-bundle` is modifying the few metadata files inside
 the previous repack operation rather than basing it on the original unpacked
 image. Therefore the cost of `--refresh-bundle` is constant, and is actually
 **much** smaller than the cost of doing additional unpack operations.
+
+### `umoci insert` ###
+
+Sometimes all you want to do is to add some files to an image (or remove some
+files) and nothing else, and in those cases doing an `umoci unpack`-`umoci
+repack` cycle is also quite expensive. This is especially true when you
+consider that OCIv1 images are backed by `tar` archives -- and the delta layer
+being generated is just going to be a `tar` archive of the files you are
+adding. The most basic usage of `umoci insert` is to just specify what files
+you want added, and what you want them to be called in the image (we don't have
+any magical `rsync` semantics -- we just copy the root to whatever path you
+tell us).
+
+{{% notice info %}}
+Note that unlike most other `umoci` commands, `umoci insert` **will overwrite
+the image you give it**. As a counter-example, the `--image` flag of `umoci
+repack` refers to the *target* image not the *source* image (the source image
+is already known, because `umoci unpack` saves that information).
+
+This behaviour may change in the future, but it's not clear what would be an
+obvious interface for this change (older versions of `umoci` had separate
+`--src` and `--dst` flags, but they were unweildly and so were removed in
+favour of the `--image` style).
+
+Also note that each `umoci insert` creates a separate layer.
+{{% /notice %}}
+
+```text
+% umoci insert --image myimg:foo mybinary /usr/bin/release-binary
+% umoci insert --image myimg:foo myconfigdir /etc/binary.d
+```
+
+If the target file already exists in previous layers, the new layer will
+overwrite any older versions of the files inserted (when extracted).
+
+You can also remove a file (or directory) from an image by using the
+`--whiteout` option, which creates a new layer with a "whiteout" entry for the
+path you give it. If the file doesn't already exist, the behaviour depends on
+the extraction tool used -- `umoci insert` will ignore whiteouts for
+non-existent files when extracting.
+
+{{% notice warning %}}
+**Do not use this to remove secrets from an image.** Since `umoci insert`
+operates by creating a new layer, older layers will still contain a copy of the
+secret you are trying to remove. If you want to avoid things from being
+included in an image in the first place, take a look at `umoci repack
+--mask-path` (which causes changes to the given paths to not be included in the
+new layer) or `umoci config --config.volumes` (which is automatically treated
+as a masked path by `umoci repack`).
+{{% /notice %}}
+
+```text
+% umoci insert --whiteout /usr/bin/old-binary
+% umoci insert --whiteout /etc/old-config.d
+```
+
+Finally, there is one more important thing to know about `umoci insert` -- how
+directory insertion is handled. By default, `umoci insert` just creates a new
+layer with the contents of the directory. When unpacked, this results in any
+existing contents in that directory (from older layers) to be merged with the
+new layer's contents. You can imagine this as though you extracted your new
+directory on top of the previous layers' cumulative directory state.
+
+But what if you want to entire replace the contents of a directory? That's the
+reason why we have `--opaque` -- it allows you to effectively blank out any
+pre-existing contents of the directory and replace it entirely with the new
+directory. If the target was not a directory in previous layers, or the source
+is not a directory, then the behaviour will depend on the tool used for
+extraction -- `umoci unpack` will just ignore the meaningless opaque whiteout
+entry.
+
+```text
+% umoci insert --opaque myetcdir /etc
+```
+
+The same caveat about `umoci insert --whiteout` applies here, as older layers
+will contain the files that were removed by the opaque whiteout.
+
+{{% notice info %}}
+It should be noted that this is the only way that umoci will currently create
+an "opaque whiteout". This means that if you need to replace an entire
+directory wholesale, the layer created by `umoci insert --opaque` is far more
+efficient in the resulting layer than the `umoci unpack`-`umoci repack` cycle
+(even if you ignore the CPU-time benefits).
+
+Though currently `umoci insert` only allows one operation per layer, which is
+mostly a UX restriction. This may change in the future, and so `umoci insert`
+will be *far* more generally usable and efficient in terms of number of layers
+generated.
+{{% /notice %}}

--- a/doc/site/quick-start/getting-an-image.md
+++ b/doc/site/quick-start/getting-an-image.md
@@ -19,17 +19,6 @@ convert a Docker image (from a registry, local daemon or even from a file saved
 with `docker save`) to an OCI image (and vice-versa). Read their documentation
 for more information about the various other formats they support.
 
-{{% notice warning %}}
-At the time of writing there is a <a
-href="https://github.com/projectatomic/skopeo/pull/420">known issue in
-skopeo</a> (and the latest release does not contain an existing hotfix), caused
-by a change in <a
-href="https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/">the
-"official" library</a>. Some images (such as the above openSUSE images) are not
-multi-arch and thus still work properly, but this should be taken into
-consideration.
-{{% /notice %}}
-
 After getting skopeo, you can download an image as follows. Note that you can
 include multiple Docker images inside the same OCI image (under different
 "tags").
@@ -58,13 +47,6 @@ Storing signatures
 At this point, you have a directory called `opensuse` which is the downloaded
 OCI image stored as a directory. This is currently the only type of layout that
 umoci can interact with.
-
-{{% notice warning %}}
-At the time of writing there is a <a
-href="https://github.com/projectatomic/skopeo/pull/306">known issue in
-skopeo</a>, which causes the above examples to not act correctly (only the
-latest image fetched will be accessible by it's tag name from the OCI image).
-{{% /notice %}}
 
 [oci-image]: https://github.com/opencontainers/image-spec
 [parcel]: https://github.com/cyphar/parcel

--- a/test/help.bats
+++ b/test/help.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats -t
-# umoci: Umoci modifies Open Containers' Images
+# umoci: Umoci Modifies Open Containers' Images
 # Copyright (C) 2016, 2017, 2018 SUSE LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats -t
 # umoci: Umoci Modifies Open Containers' Images
-# Copyright (C) 2018 Cisco
+# Copyright (C) 2018 SUSE LLC.
+# Copyright (C) 2018 Cisco Systems
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
umoci-insert(1) is quite useful, and we should tell people about it in
our documentation (especially since the need for --opaque and --whiteout
require a bit of explanation and warning). I also noticed some of our
skopeo warnings are out-of-date and so I've removed them.

Signed-off-by: Aleksa Sarai <asarai@suse.de>