### PR TITLE
umoci: allow ':' in --image (and similar flags)

### DIFF
--- a/cmd/umoci/utils_ux.go
+++ b/cmd/umoci/utils_ux.go
@@ -140,7 +140,7 @@ func uxImage(cmd cli.Command) cli.Command {
 			image := ctx.String("image")
 
 			var dir, tag string
-			sep := strings.LastIndex(image, ":")
+			sep := strings.Index(image, ":")
 			if sep == -1 {
 				dir = image
 				tag = "latest"
@@ -150,9 +150,6 @@ func uxImage(cmd cli.Command) cli.Command {
 			}
 
 			// Verify directory value.
-			if strings.Contains(dir, ":") {
-				return errors.Wrap(fmt.Errorf("path contains ':' character: '%s'", dir), "invalid --image")
-			}
 			if dir == "" {
 				return errors.Wrap(fmt.Errorf("path is empty"), "invalid --image")
 			}


### PR DESCRIPTION
9d126685960c ("oci: casext: extend scope of valid reference names")
added support for having ':' in reference names (in accordance with the
OCI specification updates), but unfortunately it missed that the primary
flag that interacts with reference names (--image) didn't support having
colons in the image tag.

Fixes #265
Signed-off-by: Aleksa Sarai <asarai@suse.de>