### PR TITLE
fix go lint link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo sh -c "apt-get -qq update && apt-get install -y gcc-multilib"
   - go get -u github.com/cpuguy83/go-md2man
   - go get -u github.com/vbatts/git-validation
-  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/lint/golint
 
 env:
   - DOCKER_IMAGE="opensuse/amd64:42.3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN zypper -n in \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN go get -u github.com/golang/lint/golint
+RUN go get -u golang.org/x/lint/golint
 RUN go get -u github.com/vbatts/git-validation && type git-validation
 
 ENV SOURCE_IMAGE=/opensuse SOURCE_TAG=latest


### PR DESCRIPTION
Change golint path to fix Travis CI jobs. 
Like this: https://travis-ci.org/openSUSE/umoci/jobs/441992106 .

xref: https://github.com/golang/lint/issues/415
xref: https://github.com/golang/lint/issues/397


Signed-off-by: Jintao Zhang <zhangjintao9020@gmail.com>