### PR TITLE
*: add --no-history to disable history auto-appending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Added
+- All umoci commands that had `--history.*` options can now decide to omit a
+  history entry with `--no-history`. Note that while this is supported for
+  commands that create layers (`umoci repack`, `umoci insert`, and `umoci raw
+  add-layer`) it is not recommended to use it for those commands since it can
+  cause other tools to become confused when inspecting the image history. The
+  primary usecase is to allow `umoci config --no-history` to leave no traces in
+  the history. See SUSE/kiwi#871. openSUSE/umoci#270
 
 ## [0.4.2] - 2018-09-11
 ## Added

--- a/cmd/umoci/config.go
+++ b/cmd/umoci/config.go
@@ -273,30 +273,33 @@ func config(ctx *cli.Context) error {
 		}
 	}
 
-	created := time.Now()
-	history := ispec.History{
-		Author:     g.Author(),
-		Comment:    "",
-		Created:    &created,
-		CreatedBy:  "umoci config",
-		EmptyLayer: true,
-	}
-
-	if val, ok := ctx.App.Metadata["--history.author"]; ok {
-		history.Author = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.comment"]; ok {
-		history.Comment = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.created"]; ok {
-		created, err := time.Parse(igen.ISO8601, val.(string))
-		if err != nil {
-			return errors.Wrap(err, "parsing --history.created")
+	var history *ispec.History
+	if !ctx.Bool("no-history") {
+		created := time.Now()
+		history = &ispec.History{
+			Author:     g.Author(),
+			Comment:    "",
+			Created:    &created,
+			CreatedBy:  "umoci config",
+			EmptyLayer: true,
 		}
-		history.Created = &created
-	}
-	if val, ok := ctx.App.Metadata["--history.created_by"]; ok {
-		history.CreatedBy = val.(string)
+
+		if ctx.IsSet("history.author") {
+			history.Author = ctx.String("history.author")
+		}
+		if ctx.IsSet("history.comment") {
+			history.Comment = ctx.String("history.comment")
+		}
+		if ctx.IsSet("history.created") {
+			created, err := time.Parse(igen.ISO8601, ctx.String("history.created"))
+			if err != nil {
+				return errors.Wrap(err, "parsing --history.created")
+			}
+			history.Created = &created
+		}
+		if ctx.IsSet("history.created_by") {
+			history.CreatedBy = ctx.String("history.created_by")
+		}
 	}
 
 	newConfig, newMeta := fromImage(g.Image())

--- a/cmd/umoci/insert.go
+++ b/cmd/umoci/insert.go
@@ -153,29 +153,32 @@ func insert(ctx *cli.Context) error {
 	reader := layer.GenerateInsertLayer(sourcePath, targetPath, ctx.IsSet("opaque"), &meta.MapOptions)
 	defer reader.Close()
 
-	created := time.Now()
-	history := ispec.History{
-		Comment:    "",
-		Created:    &created,
-		CreatedBy:  "umoci insert", // XXX: Should we append argv to this?
-		EmptyLayer: false,
-	}
-
-	if val, ok := ctx.App.Metadata["--history.author"]; ok {
-		history.Author = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.comment"]; ok {
-		history.Comment = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.created"]; ok {
-		created, err := time.Parse(igen.ISO8601, val.(string))
-		if err != nil {
-			return errors.Wrap(err, "parsing --history.created")
+	var history *ispec.History
+	if !ctx.Bool("no-history") {
+		created := time.Now()
+		history = &ispec.History{
+			Comment:    "",
+			Created:    &created,
+			CreatedBy:  "umoci insert", // XXX: Should we append argv to this?
+			EmptyLayer: false,
 		}
-		history.Created = &created
-	}
-	if val, ok := ctx.App.Metadata["--history.created_by"]; ok {
-		history.CreatedBy = val.(string)
+
+		if ctx.IsSet("history.author") {
+			history.Author = ctx.String("history.author")
+		}
+		if ctx.IsSet("history.comment") {
+			history.Comment = ctx.String("history.comment")
+		}
+		if ctx.IsSet("history.created") {
+			created, err := time.Parse(igen.ISO8601, ctx.String("history.created"))
+			if err != nil {
+				return errors.Wrap(err, "parsing --history.created")
+			}
+			history.Created = &created
+		}
+		if ctx.IsSet("history.created_by") {
+			history.CreatedBy = ctx.String("history.created_by")
+		}
 	}
 
 	// TODO: We should add a flag to allow for a new layer to be made

--- a/cmd/umoci/raw-add-layer.go
+++ b/cmd/umoci/raw-add-layer.go
@@ -124,30 +124,33 @@ func rawAddLayer(ctx *cli.Context) error {
 		return errors.Wrap(err, "get image metadata")
 	}
 
-	created := time.Now()
-	history := ispec.History{
-		Author:     imageMeta.Author,
-		Comment:    "",
-		Created:    &created,
-		CreatedBy:  "umoci raw add-layer", // XXX: Should we append argv to this?
-		EmptyLayer: false,
-	}
-
-	if val, ok := ctx.App.Metadata["--history.author"]; ok {
-		history.Author = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.comment"]; ok {
-		history.Comment = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.created"]; ok {
-		created, err := time.Parse(igen.ISO8601, val.(string))
-		if err != nil {
-			return errors.Wrap(err, "parsing --history.created")
+	var history *ispec.History
+	if !ctx.Bool("no-history") {
+		created := time.Now()
+		history = &ispec.History{
+			Author:     imageMeta.Author,
+			Comment:    "",
+			Created:    &created,
+			CreatedBy:  "umoci raw add-layer", // XXX: Should we append argv to this?
+			EmptyLayer: false,
 		}
-		history.Created = &created
-	}
-	if val, ok := ctx.App.Metadata["--history.created_by"]; ok {
-		history.CreatedBy = val.(string)
+
+		if ctx.IsSet("history.author") {
+			history.Author = ctx.String("history.author")
+		}
+		if ctx.IsSet("history.comment") {
+			history.Comment = ctx.String("history.comment")
+		}
+		if ctx.IsSet("history.created") {
+			created, err := time.Parse(igen.ISO8601, ctx.String("history.created"))
+			if err != nil {
+				return errors.Wrap(err, "parsing --history.created")
+			}
+			history.Created = &created
+		}
+		if ctx.IsSet("history.created_by") {
+			history.CreatedBy = ctx.String("history.created_by")
+		}
 	}
 
 	// TODO: We should add a flag to allow for a new layer to be made

--- a/cmd/umoci/repack.go
+++ b/cmd/umoci/repack.go
@@ -199,30 +199,33 @@ func repack(ctx *cli.Context) error {
 		return errors.Wrap(err, "get image metadata")
 	}
 
-	created := time.Now()
-	history := ispec.History{
-		Author:     imageMeta.Author,
-		Comment:    "",
-		Created:    &created,
-		CreatedBy:  "umoci config", // XXX: Should we append argv to this?
-		EmptyLayer: false,
-	}
-
-	if val, ok := ctx.App.Metadata["--history.author"]; ok {
-		history.Author = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.comment"]; ok {
-		history.Comment = val.(string)
-	}
-	if val, ok := ctx.App.Metadata["--history.created"]; ok {
-		created, err := time.Parse(igen.ISO8601, val.(string))
-		if err != nil {
-			return errors.Wrap(err, "parsing --history.created")
+	var history *ispec.History
+	if !ctx.Bool("no-history") {
+		created := time.Now()
+		history = &ispec.History{
+			Author:     imageMeta.Author,
+			Comment:    "",
+			Created:    &created,
+			CreatedBy:  "umoci repack", // XXX: Should we append argv to this?
+			EmptyLayer: false,
 		}
-		history.Created = &created
-	}
-	if val, ok := ctx.App.Metadata["--history.created_by"]; ok {
-		history.CreatedBy = val.(string)
+
+		if ctx.IsSet("history.author") {
+			history.Author = ctx.String("history.author")
+		}
+		if ctx.IsSet("history.comment") {
+			history.Comment = ctx.String("history.comment")
+		}
+		if ctx.IsSet("history.created") {
+			created, err := time.Parse(igen.ISO8601, ctx.String("history.created"))
+			if err != nil {
+				return errors.Wrap(err, "parsing --history.created")
+			}
+			history.Created = &created
+		}
+		if ctx.IsSet("history.created_by") {
+			history.CreatedBy = ctx.String("history.created_by")
+		}
 	}
 
 	// TODO: We should add a flag to allow for a new layer to be made

--- a/doc/man/umoci-config.1.md
+++ b/doc/man/umoci-config.1.md
@@ -8,6 +8,7 @@ umoci config - Modifies the configuration of an OCI image
 **umoci config**
 **--image**=*image*[:*tag*]
 [**--tag**=*new-tag*]
+[**--no-history**]
 [**--history.comment**=*comment*]
 [**--history.created_by**=*created_by*]
 [**--history.author**=*author*]
@@ -29,9 +30,9 @@ umoci config - Modifies the configuration of an OCI image
 
 # DESCRIPTION
 Modify the configuration and manifest data for a particular tagged OCI image.
-In addition, a history entry is appended to the tagged OCI image for this
-change (with the various **--history.** flags controlling the values used). To
-view the history, see **umoci-stat**(1).
+If **--no-history** was not specified, a history entry is appended to the
+tagged OCI image for this change (with the various **--history.** flags
+controlling the values used). To view the history, see **umoci-stat**(1).
 
 Note that the original image tag (the argument to **--image**) will **not** be
 modified unless the target of **umoci-config**(1) is the original image tag.
@@ -47,6 +48,9 @@ The global options are defined in **umoci**(1).
 **--tag**=*new-tag*
   Tag name for the repacked image, if unspecified then the original tag
   provided to **--image** will be clobbered.
+
+**--no-history**
+  Causes no history entry to be added for this operation.
 
 **--history.comment**=*comment*
   Comment for the history entry corresponding to this modification of the image

--- a/doc/man/umoci-insert.1.md
+++ b/doc/man/umoci-insert.1.md
@@ -11,6 +11,7 @@ umoci insert - insert content into an OCI image
 [**--rootless**]
 [**--uid-map**=*value*]
 [**--uid-map**=*value*]
+[**--no-history**]
 [**--history.comment**=*comment*]
 [**--history.created_by**=*created_by*]
 [**--history.author**=*author*]
@@ -41,6 +42,10 @@ Note that this command works by creating a new layer, so this should not be
 used to remove (or replace) secrets from an already-built image. See
 **umoci-config**(1) and **--config.volume** for how to achieve this correctly
 by not creating image layers with secrets in the first place.
+
+If **--no-history** was not specified, a history entry is appended to the
+tagged OCI image for this change (with the various **--history.** flags
+controlling the values used). To view the history, see **umoci-stat**(1).
 
 # OPTIONS
 The global options are defined in **umoci**(1).
@@ -78,6 +83,12 @@ The global options are defined in **umoci**(1).
   Specifies a GID mapping to use when inserting files. This is used in a
   similar fashion to **user_namespaces**(7), and is of the form
   **container:host[:size]**.
+
+**--no-history**
+  Causes no history entry to be added for this operation. **This is not
+  recommended for use with umoci-insert(1), since it results in the history not
+  including all of the image layers -- and thus will cause confusion with tools
+  that look at image history.**
 
 **--history.comment**=*comment*
   Comment for the history entry corresponding to this modification of the image

--- a/doc/man/umoci-raw-add-layer.1.md
+++ b/doc/man/umoci-raw-add-layer.1.md
@@ -8,6 +8,7 @@ umoci raw add-layer - add a layer archive verbatim to an image
 **umoci raw add-layer**
 **--image**=*image*
 [**--tag**=*tag*]
+[**--no-history**]
 [**--history.comment**=*comment*]
 [**--history.created_by**=*created_by*]
 [**--history.author**=*author*]
@@ -37,6 +38,12 @@ The global options are defined in **umoci**(1).
   The destination tag to use for the newly created image. *tag* must be a valid
   tag in the image. If *tag* is not provided it defaults to the *tag* specified
   in **--image** (overwriting it).
+
+**--no-history**
+  Causes no history entry to be added for this operation. **This is not
+  recommended for use with umoci-raw-add-layer(1), since it results in the
+  history not including all of the image layers -- and thus will cause
+  confusion with tools that look at image history.**
 
 **--history.comment**=*comment*
   Comment for the history entry corresponding to this modification of the image

--- a/doc/man/umoci-repack.1.md
+++ b/doc/man/umoci-repack.1.md
@@ -7,6 +7,7 @@ umoci repack - Repacks an OCI runtime bundle into an image tag
 # SYNOPSIS
 **umoci repack**
 **--image**=*image*[:*tag*]
+[**--no-history**]
 [**--history.comment**=*comment*]
 [**--history.created_by**=*created_by*]
 [**--history.author**=*author*]
@@ -27,9 +28,9 @@ All **--uid-map** and **--gid-map** settings are implied from the saved values
 specified in **umoci-unpack**(1), so they are not available for
 **umoci-repack**(1).
 
-In addition, a history entry is appended to the tagged OCI image for this
-change (with the various **--history.** flags controlling the values used). To
-view the history, see **umoci-stat**(1).
+If **--no-history** was not specified, a history entry is appended to the
+tagged OCI image for this change (with the various **--history.** flags
+controlling the values used). To view the history, see **umoci-stat**(1).
 
 Note that the original image tag (used with **umoci-unpack**(1)) will **not**
 be modified unless the target of **umoci-repack**(1) is the original image tag.
@@ -43,6 +44,12 @@ The global options are defined in **umoci**(1).
   the *bundle*) and *tag* must be a valid tag name. If another tag already has
   the same name as *tag* it will be overwritten. If *tag* is not provided it
   defaults to "latest".
+
+**--no-history**
+  Causes no history entry to be added for this operation. **This is not
+  recommended for use with umoci-repack(1), since it results in the history not
+  including all of the image layers -- and thus will cause confusion with tools
+  that look at image history.**
 
 **--history.comment**=*comment*
   Comment for the history entry corresponding to this modification of the image

--- a/test/config.bats
+++ b/test/config.bats
@@ -671,6 +671,28 @@ function teardown() {
 	image-verify "${IMAGE}"
 }
 
+@test "umoci config --no-history" {
+	# Modify something and don't add a history entry.
+	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" --no-history \
+		--author="Aleksa Sarai <asarai@suse.com>"
+	[ "$status" -eq 0 ]
+	image-verify "${IMAGE}"
+
+	# Make sure that the history was modified.
+	umoci stat --image "${IMAGE}:${TAG}" --json
+	[ "$status" -eq 0 ]
+	hashA="$(sha256sum <<<"$output")"
+
+	umoci stat --image "${IMAGE}:${TAG}-new" --json
+	[ "$status" -eq 0 ]
+	hashB="$(sha256sum <<<"$output")"
+
+	# umoci-stat output should be identical.
+	[[ "$hashA" == "$hashB" ]]
+
+	image-verify "${IMAGE}"
+}
+
 @test "umoci config --config.label" {
 	# Modify none of the configuration.
 	umoci config --image "${IMAGE}:${TAG}" --tag "${TAG}-new" \


### PR DESCRIPTION
Some users (like KIWI) want to end up with an image that only has a
single history entry for the one layer they have generated, but
umoci-config(1) normally generates a config entry for each invocation.

To allow for this usecase, a new --no-history flag was added which just
avoids adding the history in mutate/. Note that a warning will be
printed when using this flag with commands that add new layers because
layers-without-history-entries can cause lots of problems when looking
at the image information (especially if a later image is added with a
history entry -- the history entry will be incorrectly attributed to the
earlier layer).

Signed-off-by: Aleksa Sarai <asarai@suse.de>