### PR TITLE
umoci: add --tag to umoci-insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   cause other tools to become confused when inspecting the image history. The
   primary usecase is to allow `umoci config --no-history` to leave no traces in
   the history. See SUSE/kiwi#871. openSUSE/umoci#270
+- `umoci insert` now has a `--tag` option that allows you to non-destructively
+  insert files into an image. The semantics match `umoci config --tag`.
+  openSUSE/umoci#273
 
 ## [0.4.2] - 2018-09-11
 ## Added

--- a/cmd/umoci/utils_ux.go
+++ b/cmd/umoci/utils_ux.go
@@ -94,7 +94,7 @@ func uxHistory(cmd cli.Command) cli.Command {
 func uxTag(cmd cli.Command) cli.Command {
 	cmd.Flags = append(cmd.Flags, cli.StringFlag{
 		Name:  "tag",
-		Usage: "tag name",
+		Usage: "new tag name (if empty, overwrite --image tag)",
 	})
 
 	oldBefore := cmd.Before

--- a/doc/man/umoci-config.1.md
+++ b/doc/man/umoci-config.1.md
@@ -29,10 +29,11 @@ umoci config - Modifies the configuration of an OCI image
 [**--manifest.annotation**=*value*]
 
 # DESCRIPTION
-Modify the configuration and manifest data for a particular tagged OCI image.
-If **--no-history** was not specified, a history entry is appended to the
-tagged OCI image for this change (with the various **--history.** flags
-controlling the values used). To view the history, see **umoci-stat**(1).
+Modify the configuration and manifest data for a particular tagged OCI image --
+**overwriting it unless you specify --tag**. If **--no-history** was not
+specified, a history entry is appended to the tagged OCI image for this change
+(with the various **--history.** flags controlling the values used). To view
+the history, see **umoci-stat**(1).
 
 Note that the original image tag (the argument to **--image**) will **not** be
 modified unless the target of **umoci-config**(1) is the original image tag.
@@ -46,7 +47,7 @@ The global options are defined in **umoci**(1).
   *tag* is not provided it defaults to "latest".
 
 **--tag**=*new-tag*
-  Tag name for the repacked image, if unspecified then the original tag
+  Tag name for the modified image, if unspecified then the original tag
   provided to **--image** will be clobbered.
 
 **--no-history**

--- a/doc/man/umoci-insert.1.md
+++ b/doc/man/umoci-insert.1.md
@@ -7,6 +7,7 @@ umoci insert - insert content into an OCI image
 # SYNOPSIS
 **umoci insert**
 **--image**=*image*[:*tag*]
+[**--tag**=*new-tag*]
 [**--opaque**]
 [**--rootless**]
 [**--uid-map**=*value*]
@@ -27,12 +28,11 @@ umoci insert - insert content into an OCI image
 
 # DESCRIPTION
 In the first form, insert the contents of *source* into the OCI image given by
-**--image** (**overwriting it** -- this is the only **umoci**(1) command which
-currently does this). This is done by creating a new layer containing just the
-contents of *source* with a name of *target*. *source* can be either a file or
-directory, and in the latter case it will be recursed. If **--opaque** is
-specified then any paths below *target* in the previous image layers (assuming
-*target* is a directory) will be removed.
+**--image** -- **overwriting it unless you specify --tag**. This is done by
+creating a new layer containing just the contents of *source* with a name of
+*target*. *source* can be either a file or directory, and in the latter case it
+will be recursed. If **--opaque** is specified then any paths below *target* in
+the previous image layers (assuming *target* is a directory) will be removed.
 
 In the second form, inserts a "deletion entry" into the OCI image for *target*
 inside the image. This is done by inserting a layer containing just a whiteout
@@ -55,6 +55,10 @@ The global options are defined in **umoci**(1).
   the container image. *image* must be a path to a valid OCI image and *tag*
   must be a valid tag in the image. If *tag* is not provided it defaults to
   "latest".
+
+**--tag**=*new-tag*
+  Tag name for the modified image, if unspecified then the original tag
+  provided to **--image** will be clobbered.
 
 **--opaque**
   (Assuming *target* is a directory.) Add an opaque whiteout entry for *target*

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -63,13 +63,13 @@ function teardown() {
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
-	umoci insert --image "${IMAGE}:${TAG}" "${INSERTDIR}/some" /rootless
+	umoci insert --image "${IMAGE}:${TAG}" --tag "${TAG}-new" "${INSERTDIR}/some" /rootless
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
 	# Unpack after the inserts.
 	new_bundle_rootfs
-	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	umoci unpack --image "${IMAGE}:${TAG}-new" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 


### PR DESCRIPTION
Before this there was no way to make --tag non-destructive, so we just
copy the semantics from umoci-config. This won't break existing scripts
because the default is still to override (just like it is with
umoci-config).

Signed-off-by: Aleksa Sarai <asarai@suse.de>