### PR TITLE
oci: handle Go 1.10 change to FileInfoHeader 

### DIFF
--- a/oci/layer/tar_generate.go
+++ b/oci/layer/tar_generate.go
@@ -144,6 +144,10 @@ func (tg *tarGenerator) AddFile(name, path string) error {
 		return errors.Wrap(err, "convert fi to hdr")
 	}
 	hdr.Xattrs = map[string]string{}
+	// Usually incorrect for containers and was added in Go 1.10 causing
+	// changes to our output on a compiler bump...
+	hdr.Uname = ""
+	hdr.Gname = ""
 
 	name, err = normalise(name, fi.IsDir())
 	if err != nil {

--- a/test/create.bats
+++ b/test/create.bats
@@ -31,38 +31,36 @@ function teardown() {
 }
 
 @test "umoci init --layout [empty]" {
-	# Setup up $NEWIMAGE.
-	NEWIMAGE="$(setup_tmpdir)"
-	rm -rf "$NEWIMAGE"
+	# We are making a new image.
+	IMAGE="$(setup_tmpdir)/image"
 
-	# Create a new image with no tags.
-	umoci init --layout "$NEWIMAGE"
+	# Create an empty layout.
+	umoci init --layout "$IMAGE"
 	[ "$status" -eq 0 ]
-	image-verify "$NEWIMAGE"
+	image-verify "$IMAGE"
 
 	# Make sure that there's no references or blobs.
-	sane_run find "$NEWIMAGE/blobs" -type f
+	sane_run find "$IMAGE/blobs" -type f
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
 	# Note that this is _very_ dodgy at the moment because of how complicated
 	# the reference handling is now.
 	# XXX: Make sure to update this for 1.0.0-rc6 where the refname changed.
-	sane_run jq -SMr '.manifests[]? | .annotations["org.opencontainers.ref.name"] | strings' "$NEWIMAGE/index.json"
+	sane_run jq -SMr '.manifests[]? | .annotations["org.opencontainers.ref.name"] | strings' "$IMAGE/index.json"
 	[ "$status" -eq 0 ]
 	[ "${#lines[@]}" -eq 0 ]
 
 	# Make sure that the required files exist.
-	[ -f "$NEWIMAGE/oci-layout" ]
-	[ -d "$NEWIMAGE/blobs" ]
-	[ -d "$NEWIMAGE/blobs/sha256" ]
-	[ -f "$NEWIMAGE/index.json" ]
+	[ -f "$IMAGE/oci-layout" ]
+	[ -d "$IMAGE/blobs" ]
+	[ -d "$IMAGE/blobs/sha256" ]
+	[ -f "$IMAGE/index.json" ]
 
-	# Make sure that attempting to create a new image will fail.
-	umoci init --layout "$NEWIMAGE"
+	# Make sure that attempting to create a new layout will fail.
+	umoci init --layout "$IMAGE"
 	[ "$status" -ne 0 ]
-	image-verify "$NEWIMAGE"
 
-	image-verify "$NEWIMAGE"
+	image-verify "$IMAGE"
 }
 
 @test "umoci new [missing args]" {
@@ -71,29 +69,29 @@ function teardown() {
 }
 
 @test "umoci new --image" {
-	# Setup up $NEWIMAGE.
-	NEWIMAGE="$(setup_tmpdir)/image"
+	# We are making a new image.
+	IMAGE="$(setup_tmpdir)/image" TAG="latest"
 
-	# Create a new image with no tags.
-	umoci init --layout "$NEWIMAGE"
+	# Create an empty layout.
+	umoci init --layout "$IMAGE"
 	[ "$status" -eq 0 ]
-	image-verify "$NEWIMAGE"
+	image-verify "$IMAGE"
 
-	# Create a new image with another tag.
-	umoci new --image "${NEWIMAGE}:latest"
+	# Create a new image.
+	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
 	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$NEWIMAGE"
+	#image-verify "$IMAGE"
 
 	# Modify the config.
-	umoci config --image "${NEWIMAGE}" --config.user "1234:1332"
+	umoci config --image "${IMAGE}:${TAG}" --config.user "1234:1332"
 	[ "$status" -eq 0 ]
 	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$NEWIMAGE"
+	#image-verify "$IMAGE"
 
 	# Unpack the image.
 	new_bundle_rootfs
-	umoci unpack --image "${NEWIMAGE}" "$BUNDLE"
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
 	[ "$status" -eq 0 ]
 	bundle-verify "$BUNDLE"
 
@@ -118,11 +116,93 @@ function teardown() {
 	[[ "$output" == "null" ]]
 
 	# Check that the history looks sane.
-	umoci stat --image "${NEWIMAGE}" --json
+	umoci stat --image "${IMAGE}:${TAG}" --json
 	[ "$status" -eq 0 ]
 	# There should be no non-empty_layers.
 	[[ "$(echo "$output" | jq -SM '[.history[] | .empty_layer == null] | any')" == "false" ]]
 
 	# XXX: oci-image-tool validate doesn't like empty images (without layers)
-	#image-verify "$NEWIMAGE"
+	#image-verify "$IMAGE"
+}
+
+# Given the bad experiences we've had with Go compiler changes resulting in
+# inconsistent archive output, this is a simple test to check whether a Go
+# compiler update will change our expected hashes seriously. We want to be as
+# reproducible-builds friendly as possible.
+#
+# Note that we cannot do anything here that involves a JSON map because this
+# translates to a Go map which then causes *guaranteed* non-deterministic
+# behaviour and thus non-deterministic archives. Do you ever get the feeling
+# that sometimes you have to cut your losses and actually do something better
+# than to sit and suffer? Well, this is how it feels.
+@test "umoci [archive/tar regressions]" {
+	# Setup up $IMAGE.
+	IMAGE="$(setup_tmpdir)/image"
+
+	# Create a new image with no tags.
+	umoci init --layout "$IMAGE"
+	[ "$status" -eq 0 ]
+	image-verify "$IMAGE"
+
+	# Create a new image with another tag.
+	umoci new --image "${IMAGE}:${TAG}"
+	[ "$status" -eq 0 ]
+	# XXX: oci-image-tool validate doesn't like empty images (without layers)
+	#image-verify "$IMAGE"
+
+	# Unpack the image.
+	new_bundle_rootfs
+	umoci unpack --image "${IMAGE}:${TAG}" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	bundle-verify "$BUNDLE"
+
+	# Create some files. We have to make sure all of the {atime,mtime} are
+	# consistent as well as the image metadata -- so pick a specific date/time.
+	epoch="1997-03-25T13:40:00+01:00"
+
+	mkdir -p "$ROOTFS"/{usr/bin,etc,var/run}
+	mkfifo "$ROOTFS/var/run/test.fifo"
+	echo "#!/usr/bin/true" > "$ROOTFS/usr/bin/bash" ; chmod a+x "$ROOTFS/usr/bin/bash"
+	ln "$ROOTFS/usr/bin/bash" "$ROOTFS/usr/bin/sh"
+	ln "$ROOTFS/usr/bin/bash" "$ROOTFS/usr/bin/ash"
+
+	ln -s /usr/bin "$ROOTFS/bin"
+	ln -s /var/run "$ROOTFS/run"
+
+	# Make sure everything has an {mtime,atime} of $epoch. We have to do this
+	# before and after the chmod to make sure we can set the times in
+	# --rootless mode.
+	find "$ROOTFS" -print0 | xargs -0 touch --no-dereference --date="$epoch"
+	chmod a-rwx "$ROOTFS/var" && touch --date="$epoch" "$ROOTFS/var"
+
+	# Repack the image.
+	umoci repack --image "${IMAGE}:${TAG}" \
+		--history.created="$epoch" "$BUNDLE"
+	[ "$status" -eq 0 ]
+	image-verify "$IMAGE"
+
+	# Modify the configuration.
+	umoci config --image "${IMAGE}:${TAG}" \
+		--config.user="1000:100" --config.cmd="/bin/sh" \
+		--os="linux" --architecture="amd64" \
+		--created="$epoch" --history.created="$epoch"
+	[ "$status" -eq 0 ]
+	image-verify "$IMAGE"
+
+	# Remove unused blobs.
+	umoci gc --layout "$IMAGE"
+	[ "$status" -eq 0 ]
+	image-verify "$IMAGE"
+
+	# Verify that the hashes of the blobs and index match (blobs are
+	# content-addressable so using hashes is a bit silly, but whatever).
+	known_hashes=(
+		"d6cbf1632c7d81ac353cf59e469d9dc76e246ff80c048c057e9dd8f380339cae  $IMAGE/blobs/sha256/d6cbf1632c7d81ac353cf59e469d9dc76e246ff80c048c057e9dd8f380339cae"
+		"f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89  $IMAGE/blobs/sha256/f4a39a97d97aa834da7ad2d92940f9636a57e3d9b3cc7c53242451b02a6cea89"
+		"9ebaf9a7943bde8602a4bc50d772528cc3ba7b386df28a42158f863a857f7ade  $IMAGE/blobs/sha256/9ebaf9a7943bde8602a4bc50d772528cc3ba7b386df28a42158f863a857f7ade"
+		"0e40f6c0d484307d9cb9bda59a86432b4fc802934b2fcf250214ab7169ab4e7f  $IMAGE/index.json"
+	)
+	sha256sum -c <(printf '%s\n' "${known_hashes[@]}")
+
+	image-verify "$IMAGE"
 }


### PR DESCRIPTION
Go 1.10's archive/tar decided to add Uname and Gname to archives by
default[1], which obviously is a bit of an issue for us if we want to be
reproducible across Go versoins. To counter-act this we explicitly set
them all to the zero value.

To avoid chasing shadows in the future, we'll add some regression tests
to make sure that Go's archive/tar doesn't regress us again.

Normally regression tests are for your own project, but (as seen
throughout umoci's history) we are currently acting as one of the few
regression tests of many other projects. In the past we've found plenty
of Go bugs and bugs in many other OCI tools, but this was usually due to
some pretty blatant problems.

Recently though there have been a slew of increasingly subtle Go
changes. Unfortunately it's not possible for us to be certain of whether
a Go compiler update will break our reproducibility between versions,
but we should at least be able to smoke test it somewhat.

Here's hoping I never have to see this test again.

[1]: golang/go@0564e30 ("archive/tar: populate uname/gname/devmajor/devminor in FileInfoHeader")

Fixes #275 
Signed-off-by: Aleksa Sarai <asarai@suse.de>