### PR TITLE
ci: add more checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 /umoci
 /cache
-/vendor/src
-/vendor/pkg
-/vendor/github.com/openSUSE/umoci
 /umoci.cov*
+/release

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,13 @@ before_install:
   - go get -u github.com/cpuguy83/go-md2man
   - go get -u github.com/vbatts/git-validation
   - go get -u golang.org/x/lint/golint
+  - go get -u github.com/securego/gosec/cmd/gosec
 
 env:
-  - DOCKER_IMAGE="opensuse/amd64:42.3"
+  - DOCKER_IMAGE="opensuse/leap:latest"
   - DOCKER_IMAGE="fedora:latest"
-  - DOCKER_IMAGE="debian:jessie"
-  - DOCKER_IMAGE="ubuntu:16.04"
+  - DOCKER_IMAGE="debian:latest"
+  - DOCKER_IMAGE="ubuntu:latest"
 
 notifications:
     email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM opensuse/amd64:42.3
+FROM opensuse/leap:latest
 MAINTAINER "Aleksa Sarai <asarai@suse.com>"
 
 # We have to use out-of-tree repos because several packages haven't been merged
@@ -24,7 +24,7 @@ RUN zypper ar -f -p 10 -g obs://Virtualization:containers obs-vc && \
 RUN zypper -n in \
 		bats \
 		git \
-		go \
+		"go>=1.11" \
 		golang-github-cpuguy83-go-md2man \
 		go-mtree \
 		jq \

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ local-validate-go:
 	test -z "$$($(GO) vet $$($(GO) list $(PROJECT)/... | grep -vE '/vendor/|/third_party/') 2>&1 | tee /dev/stderr)"
 	@type gosec     >/dev/null 2>/dev/null || (echo "ERROR: gosec not found." && false)
 	test -z "$$(gosec -quiet -exclude=G301,G302,G304 $$GOPATH/$(PROJECT)/... | tee /dev/stderr)"
+	./hack/test-vendor.sh
 
 EPOCH_COMMIT ?= 97ecdbd53dcb72b7a0d62196df281f131dc9eb2f
 .PHONY: local-validate-git

--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,14 @@ local-validate: local-validate-git local-validate-go local-validate-reproducible
 # TODO: Remove the special-case ignored system/* warnings.
 .PHONY: local-validate-go
 local-validate-go:
-	@type gofmt    >/dev/null 2>/dev/null || (echo "ERROR: gofmt not found." && false)
+	@type gofmt     >/dev/null 2>/dev/null || (echo "ERROR: gofmt not found." && false)
 	test -z "$$(gofmt -s -l . | grep -vE '^vendor/|^third_party/' | tee /dev/stderr)"
-	@type golint   >/dev/null 2>/dev/null || (echo "ERROR: golint not found." && false)
+	@type golint    >/dev/null 2>/dev/null || (echo "ERROR: golint not found." && false)
 	test -z "$$(golint $(PROJECT)/... | grep -vE '/vendor/|/third_party/' | tee /dev/stderr)"
 	@go doc cmd/vet >/dev/null 2>/dev/null || (echo "ERROR: go vet not found." && false)
 	test -z "$$($(GO) vet $$($(GO) list $(PROJECT)/... | grep -vE '/vendor/|/third_party/') 2>&1 | tee /dev/stderr)"
+	@type gosec     >/dev/null 2>/dev/null || (echo "ERROR: gosec not found." && false)
+	test -z "$$(gosec -quiet -exclude=G301,G302,G304 $$GOPATH/$(PROJECT)/... | tee /dev/stderr)"
 
 EPOCH_COMMIT ?= 97ecdbd53dcb72b7a0d62196df281f131dc9eb2f
 .PHONY: local-validate-git

--- a/cmd/umoci/main.go
+++ b/cmd/umoci/main.go
@@ -83,7 +83,10 @@ func main() {
 			if ctx.GlobalIsSet("log") {
 				return errors.New("--log=* and --verbose are mutually exclusive")
 			}
-			ctx.GlobalSet("log", "info")
+			if err := ctx.GlobalSet("log", "info"); err != nil {
+				// Should _never_ be reached.
+				return errors.Wrap(err, "[internal error] failure auto-setting --log=info")
+			}
 		}
 
 		level, err := log.ParseLevel(ctx.GlobalString("log"))

--- a/go.mod
+++ b/go.mod
@@ -2,19 +2,19 @@ module github.com/openSUSE/umoci
 
 require (
 	github.com/apex/log v1.1.0
-	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/docker/go-units v0.3.3
-	github.com/fatih/color v1.7.0 // indirect
+	github.com/fatih/color v1.7.0
 	github.com/golang/protobuf v1.2.0
-	github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357 // indirect
-	github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0 // indirect
-	github.com/klauspost/compress v1.4.0 // indirect
-	github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 // indirect
-	github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6 // indirect
+	github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357
+	github.com/hashicorp/go-multierror v0.0.0-20180717150148-3d5d8f294aa0
+	github.com/klauspost/compress v1.4.0
+	github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5
+	github.com/klauspost/crc32 v0.0.0-20161016154125-cb6bfca970f6
 	github.com/klauspost/pgzip v0.0.0-20170402124221-0bf5dcad4ada
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/mattn/go-colorable v0.0.9
+	github.com/mattn/go-isatty v0.0.3
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/image-spec v1.0.0
@@ -22,14 +22,14 @@ require (
 	github.com/opencontainers/runtime-tools v0.7.0
 	github.com/pkg/errors v0.8.0
 	github.com/rootless-containers/proto v0.1.0
-	github.com/sirupsen/logrus v1.0.6 // indirect
-	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e // indirect
+	github.com/sirupsen/logrus v1.0.6
+	github.com/syndtr/gocapability v0.0.0-20180223013746-33e07d32887e
 	github.com/urfave/cli v1.20.0
 	github.com/vbatts/go-mtree v0.4.3
-	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
-	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v0.0.0-20180719132039-b84684d0e066 // indirect
-	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415
+	github.com/xeipuuv/gojsonschema v0.0.0-20180719132039-b84684d0e066
+	golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
 	golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a
 	golang.org/x/sys v0.0.0-20180801221139-3dc4335d56c7
 )

--- a/hack/test-vendor.sh
+++ b/hack/test-vendor.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2018 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# Generate a hash-of-hashes for the entire vendor/ tree.
+function gethash() {
+	(
+		cd "$1"
+		find . -type f | xargs sha256sum | sort -k2 | sha256sum | awk '{ print $1 }'
+	)
+}
+
+# Figure out root directory.
+export ROOT="$(readlink -f "$(dirname "$(readlink -f "$BASH_SOURCE")")/..")"
+
+# Stash away old vendor tree, and restore it on-exit.
+mv "$ROOT"/{,old_}vendor
+trap 'rm -rf "$ROOT"/vendor ; mv "$ROOT"/{old_,}vendor' EXIT
+
+# Try to re-generate vendor/ and see whether something has changed.
+oldhash="$(gethash "$ROOT/old_vendor")"
+go clean -modcache
+GO111MODULE=on go mod vendor
+newhash="$(gethash "$ROOT/vendor")"
+
+# Verify the hashes match.
+[[ "$oldhash" == "$newhash" ]] || ( echo "ERROR: vendor/ does not match go.mod -- run 'go mod vendor'" ; exit 1 )

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -170,7 +170,9 @@ func (e *dirEngine) PutBlob(ctx context.Context, reader io.Reader) (digest.Diges
 	if err != nil {
 		return "", -1, errors.Wrap(err, "copy to temporary blob")
 	}
-	fh.Close()
+	if err := fh.Close(); err != nil {
+		return "", -1, errors.Wrap(err, "close temporary blob")
+	}
 
 	// Get the digest.
 	path, err := blobPath(digester.Digest())
@@ -220,7 +222,9 @@ func (e *dirEngine) PutIndex(ctx context.Context, index ispec.Index) error {
 	if err := json.NewEncoder(fh).Encode(index); err != nil {
 		return errors.Wrap(err, "write temporary index")
 	}
-	fh.Close()
+	if err := fh.Close(); err != nil {
+		return errors.Wrap(err, "close temporary index")
+	}
 
 	// Move the blob to its correct path.
 	path := filepath.Join(e.path, indexFile)

--- a/oci/casext/blob.go
+++ b/oci/casext/blob.go
@@ -122,14 +122,15 @@ func (b *Blob) load(ctx context.Context, engine cas.Engine) error {
 }
 
 // Close cleans up all of the resources for the opened blob.
-func (b *Blob) Close() {
+func (b *Blob) Close() error {
 	switch b.MediaType {
 	case ispec.MediaTypeImageLayer, ispec.MediaTypeImageLayerNonDistributable,
 		ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayerNonDistributableGzip:
 		if b.Data != nil {
-			b.Data.(io.Closer).Close()
+			return b.Data.(io.Closer).Close()
 		}
 	}
+	return nil
 }
 
 // FromDescriptor parses the blob referenced by the given descriptor.

--- a/oci/layer/generate.go
+++ b/oci/layer/generate.go
@@ -54,7 +54,8 @@ func GenerateLayer(path string, deltas []mtree.InodeDelta, opt *MapOptions) (io.
 	go func() (Err error) {
 		// Close with the returned error.
 		defer func() {
-			writer.CloseWithError(errors.Wrap(Err, "generate layer"))
+			// #nosec G104
+			_ = writer.CloseWithError(errors.Wrap(Err, "generate layer"))
 		}()
 
 		// We can't just dump all of the file contents into a tar file. We need
@@ -116,7 +117,8 @@ func GenerateInsertLayer(root string, target string, opaque bool, opt *MapOption
 
 	go func() (Err error) {
 		defer func() {
-			writer.CloseWithError(errors.Wrap(Err, "generate layer"))
+			// #nosec G104
+			_ = writer.CloseWithError(errors.Wrap(Err, "generate layer"))
 		}()
 
 		tg := newTarGenerator(writer, mapOptions)

--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -287,6 +287,7 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 	// directory will be fixed by later archive entries.
 	if dirFi, err := te.fsEval.Lstat(dir); err == nil && path != dir {
 		// FIXME: This is really stupid.
+		// #nosec G104
 		link, _ := te.fsEval.Readlink(dir)
 		dirHdr, err := tar.FileInfoHeader(dirFi, link)
 		if err != nil {
@@ -498,14 +499,18 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 		defer fh.Close()
 
 		// We need to make sure that we copy all of the bytes.
-		if n, err := io.Copy(fh, r); err != nil {
-			return err
-		} else if int64(n) != hdr.Size {
-			return errors.Wrap(io.ErrShortWrite, "unpack to regular file")
+		n, err := io.Copy(fh, r)
+		if int64(n) != hdr.Size {
+			err = io.ErrShortWrite
+		}
+		if err != nil {
+			return errors.Wrap(err, "unpack to regular file")
 		}
 
 		// Force close here so that we don't affect the metadata.
-		fh.Close()
+		if err := fh.Close(); err != nil {
+			return errors.Wrap(err, "close unpacked regular file")
+		}
 
 	// directory
 	case tar.TypeDir:

--- a/oci/layer/utils.go
+++ b/oci/layer/utils.go
@@ -208,6 +208,7 @@ func CleanPath(path string) string {
 	if !filepath.IsAbs(path) {
 		path = filepath.Clean(string(os.PathSeparator) + path)
 		// This can't fail, as (by definition) all paths are relative to root.
+		// #nosec G104
 		path, _ = filepath.Rel(string(os.PathSeparator), path)
 	}
 

--- a/pkg/unpriv/unpriv.go
+++ b/pkg/unpriv/unpriv.go
@@ -34,6 +34,8 @@ import (
 // fiRestore restores the state given by an os.FileInfo instance at the given
 // path by ensuring that an Lstat(path) will return as-close-to the same
 // os.FileInfo.
+//
+// #nosec G104
 func fiRestore(path string, fi os.FileInfo) {
 	// archive/tar handles the OS-specific syscall stuff required to get atime
 	// and mtime information for a file.
@@ -330,7 +332,8 @@ func foreachSubpath(path string, wrapFn WrapFunc) error {
 	// permissions because we're already in a context with filepath.Dir(path)
 	// is at least a+rx. However, because we are calling wrapFn we need to
 	// restore the original mode immediately.
-	os.Chmod(path, fi.Mode()|0444)
+	// #nosec G104
+	_ = os.Chmod(path, fi.Mode()|0444)
 	names, err := fd.Readdirnames(-1)
 	fiRestore(path, fi)
 	if err != nil {

--- a/third_party/shared/util.go
+++ b/third_party/shared/util.go
@@ -46,6 +46,7 @@ func RunningInUserNS() bool {
 
 	line := string(l)
 	var a, b, c int64
+	// #nosec G104
 	fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
 	if a == 0 && b == 0 && c == 4294967295 {
 		return false

--- a/third_party/user/user.go
+++ b/third_party/user/user.go
@@ -73,6 +73,7 @@ func parseLine(line string, v ...interface{}) {
 			*e = p
 		case *int:
 			// "numbers", with conversion errors ignored because of some misbehaving configuration files.
+			// #nosec G104
 			*e, _ = strconv.Atoi(p)
 		case *[]string:
 			// Comma-separated lists.

--- a/utils.go
+++ b/utils.go
@@ -165,11 +165,9 @@ func (ms ManifestStat) Format(w io.Writer) error {
 		}
 
 		// TODO: We need to truncate some of the fields.
-
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", layerID, created, createdBy, size, comment)
 	}
-	tw.Flush()
-	return nil
+	return tw.Flush()
 }
 
 // historyStat contains information about a single entry in the history of a
@@ -290,10 +288,16 @@ func ParseIdmapOptions(meta *Meta, ctx *cli.Context) error {
 	meta.MapOptions.Rootless = ctx.Bool("rootless")
 	if meta.MapOptions.Rootless {
 		if !ctx.IsSet("uid-map") {
-			ctx.Set("uid-map", fmt.Sprintf("0:%d:1", os.Geteuid()))
+			if err := ctx.Set("uid-map", fmt.Sprintf("0:%d:1", os.Geteuid())); err != nil {
+				// Should _never_ be reached.
+				return errors.Wrap(err, "[internal error] failure auto-setting rootless --uid-map")
+			}
 		}
 		if !ctx.IsSet("gid-map") {
-			ctx.Set("gid-map", fmt.Sprintf("0:%d:1", os.Getegid()))
+			if err := ctx.Set("gid-map", fmt.Sprintf("0:%d:1", os.Getegid())); err != nil {
+				// Should _never_ be reached.
+				return errors.Wrap(err, "[internal error] failure auto-setting rootless --gid-map")
+			}
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,9 +40,9 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/validate
+github.com/opencontainers/runtime-tools/error
 github.com/opencontainers/runtime-tools/filepath
 github.com/opencontainers/runtime-tools/specerror
-github.com/opencontainers/runtime-tools/error
 # github.com/pkg/errors v0.8.0
 github.com/pkg/errors
 # github.com/rootless-containers/proto v0.1.0
@@ -64,8 +64,8 @@ github.com/xeipuuv/gojsonreference
 # github.com/xeipuuv/gojsonschema v0.0.0-20180719132039-b84684d0e066
 github.com/xeipuuv/gojsonschema
 # golang.org/x/crypto v0.0.0-20180723164146-c126467f60eb
-golang.org/x/crypto/ripemd160
 golang.org/x/crypto/ssh/terminal
+golang.org/x/crypto/ripemd160
 # golang.org/x/net v0.0.0-20180801234040-f4c29de78a2a
 golang.org/x/net/context
 # golang.org/x/sys v0.0.0-20180801221139-3dc4335d56c7


### PR DESCRIPTION
It's necessary to add CI checks for gosec as well as `go mod vendor` sanity.

Signed-off-by: Aleksa Sarai <asarai@suse.de>