### PR TITLE
oci: cas*: add blob verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Added
+- Full-stack verification of blob hashes and descriptor sizes is now done on
+  all operations, improving our hardening against bad blobs (we already did
+  some verification of layer DiffIDs but this is far more thorough).
+  openSUSE/umoci#278 openSUSE/umoci#280 openSUSE/umoci#282
 
 ## [v0.4.3] - 2018-11-11
 ## Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,9 @@ RUN zypper -n in \
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:$PATH
-RUN go get -u golang.org/x/lint/golint
-RUN go get -u github.com/vbatts/git-validation && type git-validation
+RUN go get -u golang.org/x/lint/golint && \
+    go get -u github.com/vbatts/git-validation && \
+    go get -u github.com/securego/gosec/cmd/gosec
 
 ENV SOURCE_IMAGE=/opensuse SOURCE_TAG=latest
 ARG DOCKER_IMAGE=opensuse/amd64:tumbleweed

--- a/cmd/umoci/raw-runtime-config.go
+++ b/cmd/umoci/raw-runtime-config.go
@@ -112,15 +112,15 @@ func rawConfig(ctx *cli.Context) error {
 	}
 	defer manifestBlob.Close()
 
-	if manifestBlob.MediaType != ispec.MediaTypeImageManifest {
-		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.MediaType), "invalid --image tag")
+	if manifestBlob.Descriptor.MediaType != ispec.MediaTypeImageManifest {
+		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.Descriptor.MediaType), "invalid --image tag")
 	}
 
 	// Get the manifest.
 	manifest, ok := manifestBlob.Data.(ispec.Manifest)
 	if !ok {
 		// Should _never_ be reached.
-		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
+		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.Descriptor.MediaType)
 	}
 
 	// Generate the configuration.

--- a/cmd/umoci/raw-unpack.go
+++ b/cmd/umoci/raw-unpack.go
@@ -108,8 +108,8 @@ func rawUnpack(ctx *cli.Context) error {
 	}
 	defer manifestBlob.Close()
 
-	if manifestBlob.MediaType != ispec.MediaTypeImageManifest {
-		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.MediaType), "invalid --image tag")
+	if manifestBlob.Descriptor.MediaType != ispec.MediaTypeImageManifest {
+		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.Descriptor.MediaType), "invalid --image tag")
 	}
 
 	log.WithFields(log.Fields{
@@ -122,7 +122,7 @@ func rawUnpack(ctx *cli.Context) error {
 	manifest, ok := manifestBlob.Data.(ispec.Manifest)
 	if !ok {
 		// Should _never_ be reached.
-		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
+		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.Descriptor.MediaType)
 	}
 
 	// FIXME: Currently we only support OCI layouts, not tar archives. This

--- a/cmd/umoci/unpack.go
+++ b/cmd/umoci/unpack.go
@@ -114,8 +114,8 @@ func unpack(ctx *cli.Context) error {
 	}
 	defer manifestBlob.Close()
 
-	if manifestBlob.MediaType != ispec.MediaTypeImageManifest {
-		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.MediaType), "invalid --image tag")
+	if manifestBlob.Descriptor.MediaType != ispec.MediaTypeImageManifest {
+		return errors.Wrap(fmt.Errorf("descriptor does not point to ispec.MediaTypeImageManifest: not implemented: %s", manifestBlob.Descriptor.MediaType), "invalid --image tag")
 	}
 
 	mtreeName := strings.Replace(meta.From.Descriptor().Digest.String(), ":", "_", 1)
@@ -130,7 +130,7 @@ func unpack(ctx *cli.Context) error {
 	manifest, ok := manifestBlob.Data.(ispec.Manifest)
 	if !ok {
 		// Should _never_ be reached.
-		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
+		return errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.Descriptor.MediaType)
 	}
 
 	// Unpack the runtime bundle.

--- a/mutate/mutate.go
+++ b/mutate/mutate.go
@@ -103,7 +103,7 @@ func (m *Mutator) cache(ctx context.Context) error {
 		manifest, ok := blob.Data.(ispec.Manifest)
 		if !ok {
 			// Should _never_ be reached.
-			return errors.Errorf("[internal error] unknown manifest blob type: %s", blob.MediaType)
+			return errors.Errorf("[internal error] unknown manifest blob type: %s", blob.Descriptor.MediaType)
 		}
 
 		// Make a copy of the manifest.
@@ -120,7 +120,7 @@ func (m *Mutator) cache(ctx context.Context) error {
 		config, ok := blob.Data.(ispec.Image)
 		if !ok {
 			// Should _never_ be reached.
-			return errors.Errorf("[internal error] unknown config blob type: %s", blob.MediaType)
+			return errors.Errorf("[internal error] unknown config blob type: %s", blob.Descriptor.MediaType)
 		}
 
 		// Make a copy of the config and configDescriptor.

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/openSUSE/umoci/oci/cas"
+	"github.com/openSUSE/umoci/pkg/hardening"
 	"github.com/opencontainers/go-digest"
 	imeta "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -197,7 +198,7 @@ func (e *dirEngine) GetBlob(ctx context.Context, digest digest.Digest) (io.ReadC
 		return nil, errors.Wrap(err, "compute blob path")
 	}
 	fh, err := os.Open(filepath.Join(e.path, path))
-	return fh, errors.Wrap(err, "open blob")
+	return &hardening.VerifiedReadCloser{Reader: fh, ExpectedDigest: digest}, errors.Wrap(err, "open blob")
 }
 
 // PutIndex sets the index of the OCI image to the given index, replacing the

--- a/oci/cas/dir/dir.go
+++ b/oci/cas/dir/dir.go
@@ -198,7 +198,11 @@ func (e *dirEngine) GetBlob(ctx context.Context, digest digest.Digest) (io.ReadC
 		return nil, errors.Wrap(err, "compute blob path")
 	}
 	fh, err := os.Open(filepath.Join(e.path, path))
-	return &hardening.VerifiedReadCloser{Reader: fh, ExpectedDigest: digest}, errors.Wrap(err, "open blob")
+	return &hardening.VerifiedReadCloser{
+		Reader:         fh,
+		ExpectedDigest: digest,
+		ExpectedSize:   int64(-1), // We don't know the expected size.
+	}, errors.Wrap(err, "open blob")
 }
 
 // PutIndex sets the index of the OCI image to the given index, replacing the

--- a/oci/casext/verified_blob.go
+++ b/oci/casext/verified_blob.go
@@ -1,0 +1,35 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package casext
+
+import (
+	"context"
+	"io"
+
+	"github.com/openSUSE/umoci/pkg/hardening"
+	"github.com/opencontainers/go-digest"
+)
+
+// GetVerifiedBlob returns a VerifiedReadCloser for retrieving a blob from the
+// image, which the caller must Close() *and* read-to-EOF (checking the error
+// code of both). Returns ErrNotExist if the digest is not found, and
+// ErrBlobDigestMismatch on a mismatched blob digest.
+func (e Engine) GetVerifiedBlob(ctx context.Context, digest digest.Digest) (io.ReadCloser, error) {
+	reader, err := e.GetBlob(ctx, digest)
+	return &hardening.VerifiedReadCloser{Reader: reader, ExpectedDigest: digest}, err
+}

--- a/oci/casext/verified_blob.go
+++ b/oci/casext/verified_blob.go
@@ -22,14 +22,19 @@ import (
 	"io"
 
 	"github.com/openSUSE/umoci/pkg/hardening"
-	"github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // GetVerifiedBlob returns a VerifiedReadCloser for retrieving a blob from the
 // image, which the caller must Close() *and* read-to-EOF (checking the error
 // code of both). Returns ErrNotExist if the digest is not found, and
-// ErrBlobDigestMismatch on a mismatched blob digest.
-func (e Engine) GetVerifiedBlob(ctx context.Context, digest digest.Digest) (io.ReadCloser, error) {
-	reader, err := e.GetBlob(ctx, digest)
-	return &hardening.VerifiedReadCloser{Reader: reader, ExpectedDigest: digest}, err
+// ErrBlobDigestMismatch on a mismatched blob digest. In addition, the reader
+// is limited to the descriptor.Size.
+func (e Engine) GetVerifiedBlob(ctx context.Context, descriptor ispec.Descriptor) (io.ReadCloser, error) {
+	reader, err := e.GetBlob(ctx, descriptor.Digest)
+	return &hardening.VerifiedReadCloser{
+		Reader:         reader,
+		ExpectedDigest: descriptor.Digest,
+		ExpectedSize:   descriptor.Size,
+	}, err
 }

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -210,13 +210,13 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		return errors.Wrap(err, "get config blob")
 	}
 	defer configBlob.Close()
-	if configBlob.MediaType != ispec.MediaTypeImageConfig {
-		return errors.Errorf("unpack rootfs: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.MediaType)
+	if configBlob.Descriptor.MediaType != ispec.MediaTypeImageConfig {
+		return errors.Errorf("unpack rootfs: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.Descriptor.MediaType)
 	}
 	config, ok := configBlob.Data.(ispec.Image)
 	if !ok {
 		// Should _never_ be reached.
-		return errors.Errorf("[internal error] unknown config blob type: %s", configBlob.MediaType)
+		return errors.Errorf("[internal error] unknown config blob type: %s", configBlob.Descriptor.MediaType)
 	}
 
 	// We can't understand non-layer images.
@@ -234,8 +234,8 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 			return errors.Wrap(err, "get layer blob")
 		}
 		defer layerBlob.Close()
-		if !isLayerType(layerBlob.MediaType) {
-			return errors.Errorf("unpack rootfs: layer %s: blob is not correct mediatype: %s", layerBlob.Digest, layerBlob.MediaType)
+		if !isLayerType(layerBlob.Descriptor.MediaType) {
+			return errors.Errorf("unpack rootfs: layer %s: blob is not correct mediatype: %s", layerBlob.Descriptor.Digest, layerBlob.Descriptor.MediaType)
 		}
 		layerData, ok := layerBlob.Data.(io.ReadCloser)
 		if !ok {
@@ -244,7 +244,7 @@ func UnpackRootfs(ctx context.Context, engine cas.Engine, rootfsPath string, man
 		}
 
 		layerRaw := layerData
-		if needsGunzip(layerBlob.MediaType) {
+		if needsGunzip(layerBlob.Descriptor.MediaType) {
 			// We have to extract a gzip'd version of the above layer. Also note
 			// that we have to check the DiffID we're extracting (which is the
 			// sha256 sum of the *uncompressed* layer).
@@ -308,13 +308,13 @@ func UnpackRuntimeJSON(ctx context.Context, engine cas.Engine, configFile io.Wri
 		return errors.Wrap(err, "get config blob")
 	}
 	defer configBlob.Close()
-	if configBlob.MediaType != ispec.MediaTypeImageConfig {
-		return errors.Errorf("unpack manifest: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.MediaType)
+	if configBlob.Descriptor.MediaType != ispec.MediaTypeImageConfig {
+		return errors.Errorf("unpack manifest: config blob is not correct mediatype %s: %s", ispec.MediaTypeImageConfig, configBlob.Descriptor.MediaType)
 	}
 	config, ok := configBlob.Data.(ispec.Image)
 	if !ok {
 		// Should _never_ be reached.
-		return errors.Errorf("[internal error] unknown config blob type: %s", configBlob.MediaType)
+		return errors.Errorf("[internal error] unknown config blob type: %s", configBlob.Descriptor.MediaType)
 	}
 
 	g, err := rgen.New(runtime.GOOS)

--- a/pkg/hardening/verified_reader.go
+++ b/pkg/hardening/verified_reader.go
@@ -25,9 +25,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ErrDigestMismatch indicates that VerifiedReadCloser encountered a digest
-// error on-EOF.
-var ErrDigestMismatch = errors.Errorf("verified reader digest mismatch")
+// Exported errors for verification issues that occur during processing within
+// VerifiedReadCloser. Note that you will need to use
+// "github.com/pkg/errors".Cause to get these exported errors in most cases.
+var (
+	ErrDigestMismatch = errors.Errorf("verified reader digest mismatch")
+	ErrSizeMismatch   = errors.Errorf("verified reader size mismatch")
+)
 
 // VerifiedReadCloser is a basic io.ReadCloser which allows for simple
 // verification that a stream matches an expected hash. The entire stream is
@@ -48,8 +52,16 @@ type VerifiedReadCloser struct {
 	// and an error will be returned if they don't match.
 	ExpectedDigest digest.Digest
 
+	// ExpectedSize is the expected amount of data to be read overall. If the
+	// underlying reader hasn't returned an EOF by the time this value is
+	// exceeded, an error is returned and no further reads will occur.
+	ExpectedSize int64
+
 	// digester stores the current state of the stream's hash.
 	digester digest.Digester
+
+	// currentSize is the number of bytes that have been read so far.
+	currentSize int64
 }
 
 func (v *VerifiedReadCloser) init() {
@@ -66,15 +78,63 @@ func (v *VerifiedReadCloser) init() {
 
 func (v *VerifiedReadCloser) isNoop() bool {
 	innerV, ok := v.Reader.(*VerifiedReadCloser)
-	return ok && innerV.ExpectedDigest == v.ExpectedDigest
+	return ok &&
+		innerV.ExpectedDigest == v.ExpectedDigest &&
+		innerV.ExpectedSize == v.ExpectedSize
+}
+
+func (v *VerifiedReadCloser) verify(nilErr error) error {
+	// Digest mismatch (always takes precedence)?
+	if actualDigest := v.digester.Digest(); actualDigest != v.ExpectedDigest {
+		return errors.Wrapf(ErrDigestMismatch, "expected %s not %s", v.ExpectedDigest, actualDigest)
+	}
+	// Do we need to check the size for mismatches?
+	if v.ExpectedSize >= 0 {
+		switch {
+		// Not enough bytes in the stream.
+		case v.currentSize < v.ExpectedSize:
+			return errors.Wrapf(ErrSizeMismatch, "expected %d bytes (only %d bytes in stream)", v.ExpectedSize, v.currentSize)
+
+		// We don't read the entire blob, so the message needs to be slightly adjusted.
+		case v.currentSize > v.ExpectedSize:
+			return errors.Wrapf(ErrSizeMismatch, "expected %d bytes (extra bytes in stream)", v.ExpectedSize)
+
+		}
+	}
+	// Forward the provided error.
+	return nilErr
 }
 
 // Read is a wrapper around VerifiedReadCloser.Reader, with a digest check on
 // EOF.  Make sure that you always check for EOF and read-to-the-end for all
 // files.
-func (v *VerifiedReadCloser) Read(p []byte) (int, error) {
-	// Piped to the underling read.
-	n, err := v.Reader.Read(p)
+func (v *VerifiedReadCloser) Read(p []byte) (n int, err error) {
+	// Make sure we don't read after v.ExpectedSize has been passed.
+	err = io.EOF
+	left := v.ExpectedSize - v.currentSize
+	switch {
+	// ExpectedSize has been disabled.
+	case v.ExpectedSize < 0:
+		n, err = v.Reader.Read(p)
+
+	// We still have something left to read.
+	case left > 0:
+		if int64(len(p)) > left {
+			p = p[:left]
+		}
+		// Piped to the underling read.
+		n, err = v.Reader.Read(p)
+		v.currentSize += int64(n)
+
+	// We have either read everything, or just happened to land on a boundary
+	// (with potentially more things afterwards). So we must check if there is
+	// anything left by doing a 1-byte read (Go doesn't allow for zero-length
+	// Read()s to give EOFs).
+	case left == 0:
+		// We just want to know whether we read something (n>0). #nosec G104
+		nTmp, _ := v.Reader.Read(make([]byte, 1))
+		v.currentSize += int64(nTmp)
+	}
 	// Are we going to be a noop?
 	if v.isNoop() {
 		return n, err
@@ -90,11 +150,9 @@ func (v *VerifiedReadCloser) Read(p []byte) (int, error) {
 			panic("verified reader: unreachable section") // should never be hit
 		}
 	}
-	// We have finished reading -- let's check the digest!
+	// We have finished reading -- let's verify the state!
 	if errors.Cause(err) == io.EOF {
-		if actualDigest := v.digester.Digest(); actualDigest != v.ExpectedDigest {
-			err = errors.Wrapf(ErrDigestMismatch, "expected %s not %s", v.ExpectedDigest, actualDigest)
-		}
+		err = v.verify(err)
 	}
 	return n, err
 }
@@ -113,9 +171,6 @@ func (v *VerifiedReadCloser) Close() error {
 	}
 	// Make sure we're ready.
 	v.init()
-	// Check the digest if no other errors occurred.
-	if actualDigest := v.digester.Digest(); actualDigest != v.ExpectedDigest {
-		err = errors.Wrapf(ErrDigestMismatch, "expected %s not %s", v.ExpectedDigest, actualDigest)
-	}
-	return err
+	// Verify the state.
+	return v.verify(nil)
 }

--- a/pkg/hardening/verified_reader.go
+++ b/pkg/hardening/verified_reader.go
@@ -1,0 +1,121 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hardening
+
+import (
+	"io"
+
+	"github.com/apex/log"
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+// ErrDigestMismatch indicates that VerifiedReadCloser encountered a digest
+// error on-EOF.
+var ErrDigestMismatch = errors.Errorf("verified reader digest mismatch")
+
+// VerifiedReadCloser is a basic io.ReadCloser which allows for simple
+// verification that a stream matches an expected hash. The entire stream is
+// hashed while being passed through this reader, and on EOF it will verify
+// that the hash matches the expected hash. If not, an error is returned. Note
+// that this means you need to read all input to EOF in order to find
+// verification errors.
+//
+// If Reader is a VerifiedReadCloser (with the same ExpectedDigest), all of the
+// methods are just piped to the underlying methods (with no verification in
+// the upper layer).
+type VerifiedReadCloser struct {
+	// Reader is the underlying reader.
+	Reader io.ReadCloser
+
+	// ExpectedDigest is the expected digest. When the underlying reader
+	// returns an EOF, the entire stream's sum will be compared to this hash
+	// and an error will be returned if they don't match.
+	ExpectedDigest digest.Digest
+
+	// digester stores the current state of the stream's hash.
+	digester digest.Digester
+}
+
+func (v *VerifiedReadCloser) init() {
+	// Define digester if not already set.
+	if v.digester == nil {
+		alg := v.ExpectedDigest.Algorithm()
+		if !alg.Available() {
+			log.Fatalf("verified reader: unsupported hash algorithm %s", alg)
+			panic("verified reader: unreachable section") // should never be hit
+		}
+		v.digester = alg.Digester()
+	}
+}
+
+func (v *VerifiedReadCloser) isNoop() bool {
+	innerV, ok := v.Reader.(*VerifiedReadCloser)
+	return ok && innerV.ExpectedDigest == v.ExpectedDigest
+}
+
+// Read is a wrapper around VerifiedReadCloser.Reader, with a digest check on
+// EOF.  Make sure that you always check for EOF and read-to-the-end for all
+// files.
+func (v *VerifiedReadCloser) Read(p []byte) (int, error) {
+	// Piped to the underling read.
+	n, err := v.Reader.Read(p)
+	// Are we going to be a noop?
+	if v.isNoop() {
+		return n, err
+	}
+	// Make sure we're ready.
+	v.init()
+	// Forward it to the digester.
+	if n > 0 {
+		// hash.Hash guarantees Write() never fails and is never short.
+		nWrite, err := v.digester.Hash().Write(p[:n])
+		if nWrite != n || err != nil {
+			log.Fatalf("verified reader: short write to %s Digester (err=%v)", v.ExpectedDigest.Algorithm(), err)
+			panic("verified reader: unreachable section") // should never be hit
+		}
+	}
+	// We have finished reading -- let's check the digest!
+	if errors.Cause(err) == io.EOF {
+		if actualDigest := v.digester.Digest(); actualDigest != v.ExpectedDigest {
+			err = errors.Wrapf(ErrDigestMismatch, "expected %s not %s", v.ExpectedDigest, actualDigest)
+		}
+	}
+	return n, err
+}
+
+// Close is a wrapper around VerifiedReadCloser.Reader, but with a digest check
+// which will return an error if the underlying Close() didn't.
+func (v *VerifiedReadCloser) Close() error {
+	// Piped to underlying close.
+	err := v.Reader.Close()
+	if err != nil {
+		return err
+	}
+	// Are we going to be a noop?
+	if v.isNoop() {
+		return err
+	}
+	// Make sure we're ready.
+	v.init()
+	// Check the digest if no other errors occurred.
+	if actualDigest := v.digester.Digest(); actualDigest != v.ExpectedDigest {
+		err = errors.Wrapf(ErrDigestMismatch, "expected %s not %s", v.ExpectedDigest, actualDigest)
+	}
+	return err
+}

--- a/pkg/hardening/verified_reader_test.go
+++ b/pkg/hardening/verified_reader_test.go
@@ -1,0 +1,135 @@
+/*
+ * umoci: Umoci Modifies Open Containers' Images
+ * Copyright (C) 2018 SUSE LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hardening
+
+import (
+	"bytes"
+	"crypto/rand"
+	// Needed for digest.
+	_ "crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/pkg/errors"
+)
+
+func TestVerifiedCopy(t *testing.T) {
+	for size := 1; size < 16384; size *= 2 {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			// Fill buffer with random data.
+			buffer := new(bytes.Buffer)
+			if _, err := io.CopyN(buffer, rand.Reader, int64(size)); err != nil {
+				t.Fatalf("getting random data for buffer failed: %v", err)
+			}
+
+			// Get expected hash.
+			expectedDigest := digest.SHA256.FromBytes(buffer.Bytes())
+			verifiedReader := &VerifiedReadCloser{
+				Reader:         ioutil.NopCloser(buffer),
+				ExpectedDigest: expectedDigest,
+			}
+
+			// Make sure everything if we copy-to-EOF we get no errors.
+			if _, err := io.Copy(ioutil.Discard, verifiedReader); err != nil {
+				t.Errorf("expected digest to be correct on EOF: got an error: %v", err)
+			}
+
+			// And on close we shouldn't get an error either.
+			if err := verifiedReader.Close(); err != nil {
+				t.Errorf("expected digest to be correct on Close: got an error: %v", err)
+			}
+		})
+	}
+}
+
+func TestInvalidVerifiedCopy(t *testing.T) {
+	for size := 1; size < 16384; size *= 2 {
+		t.Run(fmt.Sprintf("size_%d", size), func(t *testing.T) {
+			// Fill buffer with random data.
+			buffer := new(bytes.Buffer)
+			if _, err := io.CopyN(buffer, rand.Reader, int64(size)); err != nil {
+				t.Fatalf("getting random data for buffer failed: %v", err)
+			}
+
+			// Generate an *incorrect* hash.
+			fakeBytes := append(buffer.Bytes()[1:], 0x80)
+			expectedDigest := digest.SHA256.FromBytes(fakeBytes)
+			verifiedReader := &VerifiedReadCloser{
+				Reader:         ioutil.NopCloser(buffer),
+				ExpectedDigest: expectedDigest,
+			}
+
+			// Make sure everything if we copy-to-EOF we get the right error.
+			if _, err := io.Copy(ioutil.Discard, verifiedReader); errors.Cause(err) != ErrDigestMismatch {
+				t.Errorf("expected digest to be invalid on EOF: got wrong error: %v", err)
+			}
+
+			// And on close we shouldn't get an error either.
+			if err := verifiedReader.Close(); errors.Cause(err) != ErrDigestMismatch {
+				t.Errorf("expected digest to be invalid on Close: got wrong error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNoop(t *testing.T) {
+	// Fill buffer with random data.
+	buffer := new(bytes.Buffer)
+	if _, err := io.CopyN(buffer, rand.Reader, 256); err != nil {
+		t.Fatalf("getting random data for buffer failed: %v", err)
+	}
+
+	// Get expected hash.
+	expectedDigest := digest.SHA256.FromBytes(buffer.Bytes())
+	verifiedReader := &VerifiedReadCloser{
+		Reader:         ioutil.NopCloser(buffer),
+		ExpectedDigest: expectedDigest,
+	}
+
+	// And make an additional wrapper with the same digest ...
+	wrappedReader := &VerifiedReadCloser{
+		Reader:         verifiedReader,
+		ExpectedDigest: expectedDigest,
+	}
+
+	// ... and a different digest.
+	doubleWrappedReader := &VerifiedReadCloser{
+		Reader:         wrappedReader,
+		ExpectedDigest: digest.SHA256.FromString("foo"),
+	}
+
+	// Read from the uppermost wrapper, ignoring all errors.
+	_, _ = io.Copy(ioutil.Discard, doubleWrappedReader)
+	_ = doubleWrappedReader.Close()
+
+	// Bottom-most wrapper should've been hit.
+	if verifiedReader.digester == nil {
+		t.Errorf("verifiedReader didn't digest input")
+	}
+	// Middle wrapper is a noop.
+	if wrappedReader.digester != nil {
+		t.Errorf("wrappedReader wasn't noop'd out")
+	}
+	// Top-most wrapper is *not* a noop (different digest).
+	if doubleWrappedReader.digester == nil {
+		t.Errorf("wrappedReader was incorrectly noop'd out")
+	}
+}

--- a/test/hardening.bats
+++ b/test/hardening.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats -t
+# umoci: Umoci Modifies Open Containers' Images
+# Copyright (C) 2018 SUSE LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load helpers
+
+function setup() {
+	setup_image
+}
+
+function teardown() {
+	teardown_tmpdirs
+	teardown_image
+}
+
+@test "umoci unpack [blob hash hardening]" {
+	readarray -t allBlobs < <( cd "$IMAGE" && find "./blobs" -type f )
+	for blob in "${allBlobs[@]}"
+	do
+		# Get a clean image.
+		NEW_IMAGE="$(setup_tmpdir)"
+		cp -rT "$IMAGE" "$NEW_IMAGE"
+
+		blobHash="$(basename "$blob")" # sha256
+
+		# Corrupt our blob in a way that won't affect any other verification
+		# (such as gzip header validation).
+		case "$(file -bi "$NEW_IMAGE/$blob")" in
+		*gzip*)
+			# Re-compress it with a worse compression ratio. This, combined
+			# with the fact that different gzip implementations produce
+			# different output, means we will almost certainly get a new hash
+			# *without* invalidating the DiffID.
+			gzip -d <"$NEW_IMAGE/$blob" | gzip -3 | sponge "$NEW_IMAGE/$blob"
+
+			# Make sure it's actually a different hash.
+			[ "$(sha256sum "$NEW_IMAGE/$blob" | grep -o "$blobHash" | wc -l)" -eq 1 ]
+			;;
+		*)
+			# Add a single NUL byte at the end of the file.
+			sane_run dd if=/dev/zero of="$NEW_IMAGE/$blob" count=1 oflag=append conv=notrunc
+			[ "$status" -eq 0 ]
+			;;
+		esac
+
+		# Now let's try to extract it.
+		new_bundle_rootfs
+		umoci unpack --image "${NEW_IMAGE}:${TAG}" "$BUNDLE"
+		[ "$status" -ne 0 ]
+		echo "$output" | grep "verified reader digest mismatch"
+
+		# TODO: When "umoci stat" grows recursive information output, use that.
+		# TODO: Add more operations to check (repack might be complicated).
+	done
+}

--- a/utils.go
+++ b/utils.go
@@ -205,7 +205,7 @@ func Stat(ctx context.Context, engine casext.Engine, manifestDescriptor ispec.De
 	manifest, ok := manifestBlob.Data.(ispec.Manifest)
 	if !ok {
 		// Should _never_ be reached.
-		return stat, errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.MediaType)
+		return stat, errors.Errorf("[internal error] unknown manifest blob type: %s", manifestBlob.Descriptor.MediaType)
 	}
 
 	// Now get the config.
@@ -216,7 +216,7 @@ func Stat(ctx context.Context, engine casext.Engine, manifestDescriptor ispec.De
 	config, ok := configBlob.Data.(ispec.Image)
 	if !ok {
 		// Should _never_ be reached.
-		return stat, errors.Errorf("[internal error] unknown config blob type: %s", configBlob.MediaType)
+		return stat, errors.Errorf("[internal error] unknown config blob type: %s", configBlob.Descriptor.MediaType)
 	}
 
 	// TODO: This should probably be moved into separate functions.


### PR DESCRIPTION
Previously we didn't really check that blobs matched their hashes
directly -- most of the checks we did were based on layer DiffIDs and
similar checks.

Here we add a new casext.GetVerifiedBlob() API which wraps the
underlying reader with a VerifiedReadCloser that will verify that the
digest matches on EOF (or on Close). Users should be very careful to
ensure that they actually check all errors (such as when using
ioutil.Discard or when they do Close).

In addition, we add it to the underlying oci/cas/dir implementation
(just for safety). This adds effectively no overhead since
VerifiedReadCloser will not double-up on verification if the digest is
the same. We also add a basic verification of this as an integration and
some unit tests -- so that we can have some confidence it actually works
to protect against bad blobs.

This is an improvement to the hardened VerifiedReadCloser, such that it
now also acts as a verified LimitedReader. First of all, it actually
means we now check the length of blobs according to their descriptors.
It also allows us to avoid reading further than strictly necessary, if
we already know that the read will fail. Unfortunately, the standard
cas/dir cannot really handle this new verification properly.

Fixes #278 
Signed-off-by: Aleksa Sarai <asarai@suse.de>