### PR TITLE
pkg: system: use AT_FDCWD in UtimesNanoAt call

### DIFF
--- a/pkg/system/utime_linux.go
+++ b/pkg/system/utime_linux.go
@@ -19,10 +19,8 @@ package system
 
 import (
 	"os"
-	"path/filepath"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -35,19 +33,7 @@ func Lutimes(path string, atime, mtime time.Time) error {
 		unix.NsecToTimespec(mtime.UnixNano()),
 	}
 
-	// Split up the path.
-	dir, file := filepath.Split(path)
-	dir = filepath.Clean(dir)
-	file = filepath.Clean(file)
-
-	// Open the parent directory.
-	dirFile, err := os.OpenFile(filepath.Clean(dir), unix.O_RDONLY|unix.O_NOFOLLOW|unix.O_DIRECTORY, 0)
-	if err != nil {
-		return errors.Wrap(err, "lutimes: open parent directory")
-	}
-	defer dirFile.Close()
-
-	err = unix.UtimesNanoAt(int(dirFile.Fd()), file, times, unix.AT_SYMLINK_NOFOLLOW)
+	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
 	if err != nil {
 		return &os.PathError{Op: "lutimes", Path: path, Err: err}
 	}


### PR DESCRIPTION
Use unix.AT_FDCWD and the absolute path for unix.UtimesNanoAt in order
to avoid having to open the parent directory on each call to Lutimes.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>