### PR TITLE
test: replace incorrect use of BATS_TMPDIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ go:
 
 before_install:
   - sudo sh -c "apt-get -qq update && apt-get install -y gcc-multilib"
-  - go get -u github.com/cpuguy83/go-md2man
-  - go get -u github.com/vbatts/git-validation
-  - go get -u golang.org/x/lint/golint
-  - go get -u github.com/securego/gosec/cmd/gosec
+  - GO111MODULE=off go get -u github.com/cpuguy83/go-md2man
+  - GO111MODULE=off go get -u github.com/vbatts/git-validation
+  - GO111MODULE=off go get -u golang.org/x/lint/golint
+  - GO111MODULE=off go get -u github.com/securego/gosec/cmd/gosec
 
 env:
   - DOCKER_IMAGE="opensuse/leap:latest"
@@ -32,5 +32,5 @@ notifications:
 
 script:
   - chmod a+rwx . # Necessary to make Travis co-operate with Docker.
-  - make GOARCH=386 local-validate-build # Make sure 32-bit builds work.
-  - make DOCKER_IMAGE=$DOCKER_IMAGE ci
+  - make GO111MODULE=auto GOARCH=386 local-validate-build # Make sure 32-bit builds work.
+  - make GO111MODULE=auto DOCKER_IMAGE=$DOCKER_IMAGE ci

--- a/test/config.bats
+++ b/test/config.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 
@@ -48,9 +49,9 @@ function teardown() {
 
 	# Make sure that the config was unchanged.
 	# First clean the config.
-	jq -SM '.' "$BUNDLE_A/config.json" >"$BATS_TMPDIR/a-config.json"
-	jq -SM '.' "$BUNDLE_B/config.json" >"$BATS_TMPDIR/b-config.json"
-	sane_run diff -u "$BATS_TMPDIR/a-config.json" "$BATS_TMPDIR/b-config.json"
+	jq -SM '.' "$BUNDLE_A/config.json" >"$UMOCI_TMPDIR/a-config.json"
+	jq -SM '.' "$BUNDLE_B/config.json" >"$UMOCI_TMPDIR/b-config.json"
+	sane_run diff -u "$UMOCI_TMPDIR/a-config.json" "$UMOCI_TMPDIR/b-config.json"
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 

--- a/test/create.bats
+++ b/test/create.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/gc.bats
+++ b/test/gc.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/hardening.bats
+++ b/test/hardening.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/insert.bats
+++ b/test/insert.bats
@@ -19,6 +19,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/pack_mapping.bats
+++ b/test/pack_mapping.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/raw-add-layer.bats
+++ b/test/raw-add-layer.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 
@@ -31,7 +32,7 @@ function teardown() {
 	echo "layer1" > "$LAYER/file"
 	mkdir "$LAYER/dir1"
 	echo "layer1" > "$LAYER/dir1/file"
-	sane_run tar cvfC "$BATS_TMPDIR/layer1.tar" "$LAYER" .
+	sane_run tar cvfC "$UMOCI_TMPDIR/layer1.tar" "$LAYER" .
 	[ "$status" -eq 0 ]
 
 	# Create layer2.
@@ -40,7 +41,7 @@ function teardown() {
 	mkdir "$LAYER/dir2" "$LAYER/dir3"
 	echo "layer2" > "$LAYER/dir2/file"
 	echo "layer2" > "$LAYER/dir3/file"
-	sane_run tar cvfC "$BATS_TMPDIR/layer2.tar" "$LAYER" .
+	sane_run tar cvfC "$UMOCI_TMPDIR/layer2.tar" "$LAYER" .
 	[ "$status" -eq 0 ]
 
 	# Create layer3.
@@ -48,20 +49,20 @@ function teardown() {
 	echo "layer3" > "$LAYER/file"
 	mkdir "$LAYER/dir2"
 	echo "layer3" > "$LAYER/dir2/file"
-	sane_run tar cvfC "$BATS_TMPDIR/layer3.tar" "$LAYER" .
+	sane_run tar cvfC "$UMOCI_TMPDIR/layer3.tar" "$LAYER" .
 	[ "$status" -eq 0 ]
 
 	# Add layers to the image.
 	umoci new --image "${IMAGE}:${TAG}"
 	[ "$status" -eq 0 ]
 	#image-verify "${IMAGE}"
-	umoci raw add-layer --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/layer1.tar"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer1.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
-	umoci raw add-layer --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/layer2.tar"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer2.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
-	umoci raw add-layer --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/layer3.tar"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer3.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 
@@ -94,18 +95,18 @@ function teardown() {
 	[ "$status" -ne 0 ]
 
 	# Missing image.
-	touch "$BATS_TMPDIR/file"
-	umoci raw add-layer "$BATS_TMPDIR/file"
+	touch "$UMOCI_TMPDIR/file"
+	umoci raw add-layer "$UMOCI_TMPDIR/file"
 	[ "$status" -ne 0 ]
 
 	# Using a directory as an image file.
-	umoci raw add-layer --image="${IMAGE}:${TAG}" "$BATS_TMPDIR"
+	umoci raw add-layer --image="${IMAGE}:${TAG}" "$UMOCI_TMPDIR"
 	[ "$status" -ne 0 ]
 }
 
 @test "umoci raw add-layer [too many args]" {
-	touch "$BATS_TMPDIR/file"{1..3}
+	touch "$UMOCI_TMPDIR/file"{1..3}
 
-	umoci raw add-layer --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/file"{1..3}
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/file"{1..3}
 	[ "$status" -ne 0 ]
 }

--- a/test/raw-config.bats
+++ b/test/raw-config.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 
@@ -46,9 +47,9 @@ function teardown() {
 
 	# Make sure that the config was unchanged.
 	# First clean the config.
-	jq -SM '.' "$BUNDLE_A/config.json" >"$BATS_TMPDIR/a-config.json"
-	jq -SM '.' "$BUNDLE_B/config.json" >"$BATS_TMPDIR/b-config.json"
-	sane_run diff -u "$BATS_TMPDIR/a-config.json" "$BATS_TMPDIR/b-config.json"
+	jq -SM '.' "$BUNDLE_A/config.json" >"$UMOCI_TMPDIR/a-config.json"
+	jq -SM '.' "$BUNDLE_B/config.json" >"$UMOCI_TMPDIR/b-config.json"
+	sane_run diff -u "$UMOCI_TMPDIR/a-config.json" "$UMOCI_TMPDIR/b-config.json"
 	[ "$status" -eq 0 ]
 	[ -z "$output" ]
 }

--- a/test/raw-unpack.bats
+++ b/test/raw-unpack.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/repack.bats
+++ b/test/repack.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/stat.bats
+++ b/test/stat.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 

--- a/test/tag.bats
+++ b/test/tag.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 
@@ -153,7 +154,7 @@ function teardown() {
 	done
 
 	# Make sure it's truly gone.
-	umoci unpack --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/notused"
+	umoci unpack --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/notused"
 	[ "$status" -ne 0 ]
 
 	# ... like, really gone.

--- a/test/unpack.bats
+++ b/test/unpack.bats
@@ -17,6 +17,7 @@
 load helpers
 
 function setup() {
+	setup_tmpdirs
 	setup_image
 }
 
@@ -279,11 +280,11 @@ function teardown() {
 	touch "$ROOTFS/link2/c"
 	mkdir "$ROOTFS/loop1" # == /loop{1..4} ... (symlink loop)
 	touch "$ROOTFS/loop1/broken"
-	sane_run tar cvfC "$BATS_TMPDIR/layer1.tar" "$ROOTFS" .
+	sane_run tar cvfC "$UMOCI_TMPDIR/layer1.tar" "$ROOTFS" .
 	[ "$status" -eq 0 ]
 
 	# Insert our fake layer manually.
-	umoci raw add-layer --image "${IMAGE}:${TAG}" "$BATS_TMPDIR/layer1.tar"
+	umoci raw add-layer --image "${IMAGE}:${TAG}" "$UMOCI_TMPDIR/layer1.tar"
 	[ "$status" -eq 0 ]
 	image-verify "${IMAGE}"
 


### PR DESCRIPTION
The code that used $BATS_TMPDIR was written before I noticed that it's
actually not a per-test random directory and is instead a way of
referencing /tmp. In particular, the use of $BATS_TMPDIR for $IMAGE was
a blocker for using the new parallel job support I'm working on adding
to bats.

In order to make this not too repetitive, I've created a new
$UMOCI_TMPDIR which is randomised for each test run.

Signed-off-by: Aleksa Sarai <asarai@suse.de>