### PR TITLE
test: use bats --jobs support to speed up tests 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ MAINTAINER "Aleksa Sarai <asarai@suse.com>"
 # We have to use out-of-tree repos because several packages haven't been merged
 # into openSUSE:Factory yet.
 RUN zypper ar -f -p 10 -g obs://Virtualization:containers obs-vc && \
+	zypper ar -f -p 10 -g obs://home:cyphar:bats obs-bats && \
 	zypper --gpg-auto-import-keys -n ref && \
 	zypper -n up
 RUN zypper -n in \

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -35,7 +35,7 @@ fi
 # Run the tests and collate the results.
 tests=()
 if [[ -z "$TESTS" ]]; then
-	tests=($ROOT/test/*.bats)
+	tests=("$ROOT/test/"*.bats)
 else
 	for f in $TESTS; do
 		tests+=("$ROOT/test/$f.bats")
@@ -43,7 +43,7 @@ else
 fi
 bats -t ${tests[*]}
 if [ "$COVER" -eq 1 ]; then
-	[ "$COVERAGE" ] && $ROOT/hack/collate.awk $COVERAGE_DIR/* $COVERAGE | sponge $COVERAGE
+	[ "$COVERAGE" ] && "$ROOT/hack/collate.awk" "$COVERAGE_DIR/"* "$COVERAGE" | sponge "$COVERAGE"
 fi
 
 # Clean up the coverage directory.

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -41,7 +41,7 @@ else
 		tests+=("$ROOT/test/$f.bats")
 	done
 fi
-bats -t ${tests[*]}
+bats --jobs "+1" --tap "${tests[@]}"
 if [ "$COVER" -eq 1 ]; then
 	[ "$COVERAGE" ] && "$ROOT/hack/collate.awk" "$COVERAGE_DIR/"* "$COVERAGE" | sponge "$COVERAGE"
 fi

--- a/test/config.bats
+++ b/test/config.bats
@@ -124,8 +124,8 @@ function teardown() {
 		# Check the actual values.
 		sane_run jq -SMr '.process.user.additionalGids[]' "$BUNDLE/config.json"
 		[ "$status" -eq 0 ]
-		printf -- '%s\n' "${lines[*]}" | grep '^9001$'
-		printf -- '%s\n' "${lines[*]}" | grep '^2581$'
+		printf -- '%s\n' "${lines[@]}" | grep '^9001$'
+		printf -- '%s\n' "${lines[@]}" | grep '^2581$'
 	else
 		# In rootless containers additionalGids should be empty.
 		[[ "$output" == 0 ]]
@@ -134,7 +134,7 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
 	[[ "$HOME" == "/my home dir " ]]
 
 	image-verify "${IMAGE}"
@@ -187,7 +187,8 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
+	sane_run declare -p output
 	[[ "$HOME" == "/my home dir " ]]
 
 	image-verify "${IMAGE}"
@@ -235,7 +236,8 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
+	sane_run declare -p output
 	[[ "$HOME" == "/my home dir " ]]
 
 	# Modify /etc/passwd and /etc/group.
@@ -266,7 +268,8 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
+	sane_run declare -p output
 	[[ "$HOME" == "/another  home" ]]
 
 	image-verify "${IMAGE}"
@@ -350,15 +353,15 @@ function teardown() {
 
 	sane_run jq -SMr '.process.env[] | startswith("HOME=")' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	[[ "${lines[*]}" == *"true"* ]]
+	[[ "${lines[@]}" == *"true"* ]]
 
 	sane_run jq -SMr '.process.env[] | startswith("PATH=")' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	[[ "${lines[*]}" == *"true"* ]]
+	[[ "${lines[@]}" == *"true"* ]]
 
 	sane_run jq -SMr '.process.env[] | startswith("TERM=")' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	[[ "${lines[*]}" == *"true"* ]]
+	[[ "${lines[@]}" == *"true"* ]]
 
 	image-verify "${IMAGE}"
 }
@@ -390,7 +393,7 @@ function teardown() {
 	[ "$numDefs" -eq "$numVars" ]
 
 	# Set the variables.
-	export $output
+	export "${lines[@]}"
 	[[ "$VARIABLE1" == "test" ]]
 	[[ "$VARIABLE2" == "what" ]]
 
@@ -523,8 +526,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	printf -- '%s\n' "${lines[*]}" | grep '^/volume$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$'
 
 	# Make sure we're appending.
 	umoci config --image "${IMAGE}:${TAG}" --config.volume "/another volume"
@@ -542,9 +545,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	printf -- '%s\n' "${lines[*]}" | grep '^/volume$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/another volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/another volume$'
 
 	# Now clear the volumes
 	umoci config --image "${IMAGE}:${TAG}" --clear=config.volume --config.volume "/..final_volume"
@@ -562,10 +565,10 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/volume$' )
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$' )
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/another volume$' )
-	printf -- '%s\n' "${lines[*]}" | grep '^/\.\.final_volume$'
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/volume$' )
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$' )
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/another volume$' )
+	printf -- '%s\n' "${lines[@]}" | grep '^/\.\.final_volume$'
 
 	image-verify "${IMAGE}"
 }

--- a/test/gc.bats
+++ b/test/gc.bats
@@ -132,7 +132,7 @@ function teardown() {
 	[ "${#lines[@]}" -gt 0 ]
 	image-verify "${IMAGE}"
 
-	for line in "${lines[*]}"; do
+	for line in "${lines[@]}"; do
 		umoci rm --image "${IMAGE}:${line}"
 		[ "$status" -eq 0 ]
 		image-verify "${IMAGE}"

--- a/test/raw-config.bats
+++ b/test/raw-config.bats
@@ -175,7 +175,7 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
 	[[ "$HOME" == "/my home dir " ]]
 
 	# Modify /etc/passwd and /etc/group.
@@ -200,7 +200,7 @@ function teardown() {
 	# Check that HOME is set.
 	sane_run jq -SMr '.process.env[]' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	export $output
+	export "${lines[@]}"
 	[[ "$HOME" == "/another  home" ]]
 
 	image-verify "${IMAGE}"
@@ -293,11 +293,11 @@ function teardown() {
 
 	sane_run jq -SMr '.process.env[] | startswith("PATH=")' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	[[ "${lines[*]}" == *"true"* ]]
+	[[ "${lines[@]}" == *"true"* ]]
 
 	sane_run jq -SMr '.process.env[] | startswith("TERM=")' "$BUNDLE/config.json"
 	[ "$status" -eq 0 ]
-	[[ "${lines[*]}" == *"true"* ]]
+	[[ "${lines[@]}" == *"true"* ]]
 
 	image-verify "${IMAGE}"
 }
@@ -328,7 +328,7 @@ function teardown() {
 	[ "$numDefs" -eq "$numVars" ]
 
 	# Set the variables.
-	export $output
+	export "${lines[@]}"
 	[[ "$VARIABLE1" == "test" ]]
 	[[ "$VARIABLE2" == "what" ]]
 
@@ -455,8 +455,8 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	printf -- '%s\n' "${lines[*]}" | grep '^/volume$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$'
 
 	# Make sure we're appending.
 	umoci config --image "${IMAGE}:${TAG}" --config.volume "/another volume"
@@ -473,9 +473,9 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	printf -- '%s\n' "${lines[*]}" | grep '^/volume$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$'
-	printf -- '%s\n' "${lines[*]}" | grep '^/another volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/volume$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$'
+	printf -- '%s\n' "${lines[@]}" | grep '^/another volume$'
 
 	# Now clear the volumes
 	umoci config --image "${IMAGE}:${TAG}" --clear=config.volume --config.volume "/..final_volume"
@@ -492,10 +492,10 @@ function teardown() {
 	[ "$status" -eq 0 ]
 
 	# Check mounts.
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/volume$' )
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/some nutty/path name/ here$' )
-	! ( printf -- '%s\n' "${lines[*]}" | grep '^/another volume$' )
-	printf -- '%s\n' "${lines[*]}" | grep '^/\.\.final_volume$'
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/volume$' )
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/some nutty/path name/ here$' )
+	! ( printf -- '%s\n' "${lines[@]}" | grep '^/another volume$' )
+	printf -- '%s\n' "${lines[@]}" | grep '^/\.\.final_volume$'
 
 	image-verify "${IMAGE}"
 }


### PR DESCRIPTION
There were a few changes to run() made in bats 1.0, and these broke some
incorrectly-written tests. Fixing this was mostly a few trivial cases of
using "@{foo[@]}" where we weren't previously.

Use the [*not-yet-merged* parallelism support I've been working on in
bats][1] in order to speed up our tests massively. This requires that we
use my home project on OBS, but hopefully my patches will be merged
eventually.

[1]: https://github.com/bats-core/bats-core/pull/172

Signed-off-by: Aleksa Sarai <asarai@suse.de>