### PR TITLE
hack: release: make version and arch configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ umoci.cover: $(GO_SRC)
 
 .PHONY: release
 release:
-	hack/release.sh -S "$(GPG_KEYID)" -r release/$(VERSION) -v $(VERSION)
+	hack/release.sh -v $(VERSION) -S "$(GPG_KEYID)"
 
 .PHONY: install
 install: umoci doc

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,17 +2,9 @@
 # release.sh: configurable signed-artefact release script
 # Copyright (C) 2016-2019 SUSE LLC.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 set -Eeuo pipefail
 


### PR DESCRIPTION
In order to be able to handle projects where the version is generated
differently (such as autotools), and using Go for determining the
architecture makes no sense move the generation of those variables to
the user-configurable section.

Signed-off-by: Aleksa Sarai <asarai@suse.de>