### PR TITLE
layer: specify "type: bind" in config.json for bind-mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+## Fixed
+- Use `type: bind` for generated `config.json` bind-mounts. While this doesn't
+  make too much sense (see opencontainers/runc#2035), it does mean that
+  rootless containers work properly with newer `runc` releases (which appear to
+  have regressed when handling file-based bind-mounts with a "bad" `type`).
+  openSUSE/umoci#294 openSUSE/umoci#295
 
 ## [0.4.4] - 2019-01-30
 ## Added

--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -351,9 +351,10 @@ func UnpackRuntimeJSON(ctx context.Context, engine cas.Engine, configFile io.Wri
 			return errors.Wrapf(err, "inspecting mount flags of %s", resolvConf)
 		}
 		g.AddMount(rspec.Mount{
+			// NOTE: "type: bind" is silly here, see opencontainers/runc#2035.
+			Type:        "bind",
 			Destination: resolvConf,
 			Source:      resolvConf,
-			Type:        "none",
 			Options:     append(unprivOpts, []string{"bind", "ro"}...),
 		})
 	}
@@ -410,9 +411,10 @@ func ToRootless(spec *rspec.Spec) {
 	}
 	// Add the sysfs mount as an rbind.
 	mounts = append(mounts, rspec.Mount{
+		// NOTE: "type: bind" is silly here, see opencontainers/runc#2035.
+		Type:        "bind",
 		Source:      "/sys",
 		Destination: "/sys",
-		Type:        "none",
 		Options:     []string{"rbind", "nosuid", "noexec", "nodev", "ro"},
 	})
 	spec.Mounts = mounts


### PR DESCRIPTION
Due to an oversight in runc, setting a type other than "" or "bind" will
result in weird errors (especially when dealing with file-based
bind-mounts).

To get around this, we can simply set an empty type. This oversight is
being dealt with upstream, but won't help old runc releases (so we need
this workaround -- and we use "bind" to work with much older releases as
well).

Fixes: #294
Signed-off-by: Aleksa Sarai <asarai@suse.de>