### PR TITLE
tar_extract: don't mask original error on short write

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -501,7 +501,7 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 		// We need to make sure that we copy all of the bytes.
 		n, err := io.Copy(fh, r)
 		if int64(n) != hdr.Size {
-			err = io.ErrShortWrite
+			err = errors.Wrapf(io.ErrShortWrite, "didn't write all the bytes to the new file (%s)", err)
 		}
 		if err != nil {
 			return errors.Wrap(err, "unpack to regular file")


### PR DESCRIPTION
The original error may be useful in figuring out *why* the short write
happened, so let's not mask it and instead include it in the new error.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>