### PR TITLE
tar_extract: don't error on fs without xattr support

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -158,11 +158,8 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 					continue
 				}
 			}
-			if te.partialRootless {
-				log.Warnf("rootless{%s} ignoring forbidden xattr: %q", hdr.Name, name)
-				continue
-			}
-			return errors.Errorf("restore xattr metadata: saw forbidden xattr %q: %s", name, hdr.Name)
+			log.Warnf("xattr{%s} ignoring forbidden xattr: %q", hdr.Name, name)
+			continue
 		}
 		if err := te.fsEval.Lsetxattr(path, name, value, 0); err != nil {
 			// In rootless mode, some xattrs will fail (security.capability).

--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -131,9 +131,14 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 	// Apply xattrs. In order to make sure that we *only* have the xattr set we
 	// want, we first clear the set of xattrs from the file then apply the ones
 	// set in the tar.Header.
-	if err := te.fsEval.Lclearxattrs(path, ignoreXattrs); err != nil {
-		return errors.Wrapf(err, "clear xattr metadata: %s", path)
+	err := te.fsEval.Lclearxattrs(path, ignoreXattrs)
+	if err != nil {
+		if errors.Cause(err) != unix.ENOTSUP {
+			return errors.Wrapf(err, "clear xattr metadata: %s", path)
+		}
+		log.Warnf("xattr{%s} ignoring ENOTSUP on clearxattrs", path)
 	}
+
 	for name, value := range hdr.Xattrs {
 		value := []byte(value)
 
@@ -176,7 +181,7 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 			// that extended attributes are simply unsupported by the
 			// underlying filesystem (such as AUFS or NFS).
 			if errors.Cause(err) == unix.ENOTSUP {
-				log.Warnf("xatt{%s} ignoring ENOTSUP on setxattr %q", hdr.Name, name)
+				log.Warnf("xattr{%s} ignoring ENOTSUP on setxattr %q", hdr.Name, name)
 				continue
 			}
 			return errors.Wrapf(err, "restore xattr metadata: %s", path)
@@ -306,7 +311,10 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 		//       tar_generate.go.
 		xattrs, err := te.fsEval.Llistxattr(dir)
 		if err != nil {
-			return errors.Wrap(err, "get dirHdr.Xattrs")
+			if errors.Cause(err) != unix.ENOTSUP {
+				return errors.Wrap(err, "get dirHdr.Xattrs")
+			}
+			log.Warnf("xattr{%s} ignoring ENOTSUP on llistxattr", dir)
 		}
 		if len(xattrs) > 0 {
 			dirHdr.Xattrs = map[string]string{}


### PR DESCRIPTION
This is a simple proposal to address #303 - I understand this may be naive / it may be that inability to deal with the `xattrs` is considered more than a warning.

Closes #303

If we are extracting to a filesystem that does not support xattrs, make
sure that an ENOTSUP from clearxattr or listxattr results in a warning,
not an error.

Signed-off-by: David Trudgian <dave@trudgian.net>