### PR TITLE
tar_extract: only warn for forbidden xattrs

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -153,11 +153,8 @@ func (te *TarExtractor) restoreMetadata(path string, hdr *tar.Header) error {
 					continue
 				}
 			}
-			if te.partialRootless {
-				log.Warnf("rootless{%s} ignoring forbidden xattr: %q", hdr.Name, name)
-				continue
-			}
-			return errors.Errorf("restore xattr metadata: saw forbidden xattr %q: %s", name, hdr.Name)
+			log.Warnf("xattr{%s} ignoring forbidden xattr: %q", hdr.Name, name)
+			continue
 		}
 		if err := te.fsEval.Lsetxattr(path, name, value, 0); err != nil {
 			// In rootless mode, some xattrs will fail (security.capability).


### PR DESCRIPTION
Closes #302

Rootless mode currently warns if a forbidden xattr is seen, while
extractions as root error out. Make root extractions warn, so that
docker images such as cern/sl6-base:latest can be extracted as root
without failing due to this error.

Signed-off-by: David Trudgian <dave@trudgian.net>