### PR TITLE
tar_extract: don't mask original error on short write

### DIFF
--- a/oci/layer/tar_extract.go
+++ b/oci/layer/tar_extract.go
@@ -506,7 +506,11 @@ func (te *TarExtractor) UnpackEntry(root string, hdr *tar.Header, r io.Reader) (
 		// We need to make sure that we copy all of the bytes.
 		n, err := io.Copy(fh, r)
 		if int64(n) != hdr.Size {
-			err = io.ErrShortWrite
+			if err != nil {
+				err = errors.Wrapf(err, "short write")
+			} else {
+				err = io.ErrShortWrite
+			}
 		}
 		if err != nil {
 			return errors.Wrap(err, "unpack to regular file")


### PR DESCRIPTION
If there was an error in io.Copy() which resulted in a short write, we
used to hide the error (though the error would be quite useful for
debugging). Thus only set err to io.ErrShortWrite if there's no error
set already.

Fixes #301
Reported-by: Tycho Andersen <tycho@tycho.ws>
Signed-off-by: Aleksa Sarai <asarai@suse.de>