### PR TITLE
tar_extract: only warn once about xattr ENOTSUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- Suppress repeated xattr warnings on destination filesystems that do not
+  support xattrs.
 
 ## [0.4.5] - 2019-12-04
 ## Added


### PR DESCRIPTION
When a destination filesystem does not support xattrs we are rasing at
least 1 ENOTSUP related warning per file. This is unhelpful, and can
scroll the terminal obscuring more important warnings. Instead, show a
single warning for the first occurrence, with an improved explanation of
the cause.

Signed-off-by: David Trudgian <dave@trudgian.net>