### PR TITLE
unpack: clean up error message

### DIFF
--- a/oci/layer/unpack.go
+++ b/oci/layer/unpack.go
@@ -113,9 +113,9 @@ func UnpackManifest(ctx context.Context, engine cas.Engine, bundle string, manif
 
 	if _, err := os.Lstat(configPath); !os.IsNotExist(err) {
 		if err == nil {
-			err = fmt.Errorf("config.json already exists")
+			return errors.Errorf("config.json already exists in %s", bundle)
 		}
-		return errors.Wrap(err, "bundle path empty")
+		return errors.Wrap(err, "problem accessing bundle config")
 	}
 
 	defer func() {


### PR DESCRIPTION
Right now this is something like:

error: config.json already exists
bundle path empty

which is silly and confusing. Let's just return the "already exists" as an
error. Additionally, the "bundle path empty" message is wrong, this error
can only occur when there's a problem accessing the bundle path (that is:
it is not an IsNotExist() error), so it's explicitly not empty :)

Signed-off-by: Tycho Andersen <tycho@tycho.ws>